### PR TITLE
Add GitHub Actions for CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,13 +13,13 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: ''
+          node-version: '16'
           check-latest: true
           cache: 'npm'
       - name: Install Dependencies
         run: npm ci
 
-  lint-typecheck:
+  lint-typecheck-format:
     runs-on: ubuntu-latest
     needs: setup
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,53 @@
+name: CI
+
+on:
+  push:
+
+  workflow_dispatch:
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ''
+          check-latest: true
+          cache: 'npm'
+      - name: Install Dependencies
+        run: npm ci
+
+  lint-typecheck:
+    runs-on: ubuntu-latest
+    needs: setup
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+          check-latest: true
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run lint:nocache
+      - run: npm run typecheck
+      - run: npm run prettier
+
+  test:
+    runs-on: ubuntu-latest
+    needs: setup
+    strategy:
+      matrix:
+        node: ['12', '14', '16']
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node }}
+          check-latest: true
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run test:ci

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # mvom
 
 MultiValue Object Mapper
+
+test

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
 # mvom
 
 MultiValue Object Mapper
-
-test

--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -1,9 +1,0 @@
-image: node:fermium
-pipelines:
-  default:
-    - step:
-        caches:
-          - node
-        script: # Modify the commands below to build your repository.
-          - npm install
-          - npm test

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "style:fix": "npm-run-all prettier:fix lint:fix",
     "test": "npm-run-all --parallel typecheck prettier lint && npm run test:coverage:summary",
     "test:unit": "jest",
+    "test:ci": "node --expose-gc --no-compilation-cache --max-old-space-size=512 ./node_modules/jest/bin/jest --ci --maxWorkers=4 --reporters=default --collectCoverage --coverageReporters text-summary",
     "test:coverage": "jest --collectCoverage --coverageReporters text",
     "test:coverage:html": "jest --collectCoverage --coverageReporters html",
     "test:coverage:summary": "jest --collectCoverage --coverageReporters text-summary",


### PR DESCRIPTION
This PR adds a CI GitHub Action to lint, typecheck, format, and run the test suite on all pushes.

I grouped the lint, typecheck, and format scripts into one job and the test in a separate job to run in parallel with the lint/typecheck/format job. For the test job I used the matrix option to run tests against node 12, 14, and 16.

A new test script `test:ci` was added to include the options we use in our service test suites.