### PR TITLE
Drop support for node 12

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -3,7 +3,7 @@ module.exports = {
 	env: {
 		build: {
 			ignore: ['**/*.test.ts', '**/__mocks__/**'],
-			presets: [['@babel/env', { targets: { node: '12.22.0' } }], '@babel/typescript'],
+			presets: [['@babel/env', { targets: { node: '14.19.0' } }], '@babel/typescript'],
 		},
 		debug: { sourceMaps: 'inline', retainLines: true },
 	},

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ jobs:
     needs: setup
     strategy:
       matrix:
-        node: ['12', '14', '16']
+        node: ['14', '16']
 
     steps:
       - uses: actions/checkout@v3

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
         "typescript": "4.6.2"
       },
       "engines": {
-        "node": ">=12.22"
+        "node": ">=14.19"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Multivalue Object Mapper",
   "main": "index.js",
   "engines": {
-    "node": ">=12.22"
+    "node": ">=14.19"
   },
   "scripts": {
     "build": "npm-run-all build:node build:prepare-unibasic build:copy-files build:declaration",


### PR DESCRIPTION
Node 12 is EOL is a little more than a month.  Since the next release of this library will be a breaking change anyway, it makes sense to drop support for Node 12 at this time.   This PR adjusts the following to eliminate support for Node 12:
* `package.json` engines is now minimum `14.19`
* Babel compilation target is node `14.19.0`
* CI workflow adjusted to no longer run against node@12