### PR TITLE
Ensure that the prettier property is dropped from dist package.json

### DIFF
--- a/scripts/copy-files.ts
+++ b/scripts/copy-files.ts
@@ -9,7 +9,7 @@ const buildPath = path.resolve(process.cwd(), './dist');
 const createPackageFile = async (): Promise<void> => {
 	const source = path.resolve(process.cwd(), './package.json');
 	const packageFile = await fse.readFile(source, 'utf8');
-	const { scripts, devDependencies, ...packageDataOther } = JSON.parse(packageFile);
+	const { scripts, devDependencies, prettier, ...packageDataOther } = JSON.parse(packageFile);
 
 	const newPackageData = {
 		...packageDataOther,


### PR DESCRIPTION
During the last publish I noticed that the `dist` folder's `package.json` still contained the `prettier` property which is unnecessary for the published version.  This PR updates the `copy-files` script to ensure that it does not get copied into the published version.