### PR TITLE
Fix _id enumerability on Model

### DIFF
--- a/src/__tests__/compileModel.test.ts
+++ b/src/__tests__/compileModel.test.ts
@@ -51,6 +51,13 @@ describe('_id accessors', () => {
 		model._id = 'test';
 		expect(model._id).toBe('test');
 	});
+
+	test('_id should be enumerable on own properties of Model', () => {
+		const Model = compileModel(connectionMock, schema, filename);
+		const model = new Model({ record: [] });
+
+		expect(Object.keys(model)).toContain('_id');
+	});
 });
 
 describe('deleteById', () => {

--- a/src/compileModel.ts
+++ b/src/compileModel.ts
@@ -64,6 +64,9 @@ const compileModel = <TSchema extends GenericObject = GenericObject>(
 		/** Document version hash */
 		public readonly __v: string | null;
 
+		/** Id of model instance */
+		public _id!: string | null; // add definite assignment assertion since property is assigned through defineProperty
+
 		/** Private id tracking property */
 		#_id: string | null;
 
@@ -78,10 +81,16 @@ const compileModel = <TSchema extends GenericObject = GenericObject>(
 			this.#_id = _id;
 			this.__v = __v;
 
-			Object.defineProperty(this, '__id', {
-				writable: true,
-				configurable: false,
-				enumerable: false,
+			Object.defineProperty(this, '_id', {
+				enumerable: true,
+				get: () => this.#_id,
+				set: (value) => {
+					if (this.#_id != null) {
+						throw new Error('_id value cannot be changed once set');
+					}
+
+					this.#_id = value;
+				},
 			});
 
 			Model.connection.logger.debug(`creating new instance of model for file ${Model.file}`);
@@ -92,20 +101,6 @@ const compileModel = <TSchema extends GenericObject = GenericObject>(
 					`error transforming data -- file: ${Model.file}; _id: ${this._id}; class: ${error.transformClass}; value: ${error.transformValue}`,
 				);
 			});
-		}
-
-		/** _id getter */
-		public get _id(): string | null {
-			return this.#_id;
-		}
-
-		/** _id setter */
-		public set _id(value) {
-			if (this.#_id != null) {
-				throw new Error('_id value cannot be changed once set');
-			}
-
-			this.#_id = value;
 		}
 
 		/** Delete a document */


### PR DESCRIPTION
The `_id` property on the `Model` instance has a getter and setter to prevent overwrite of the id.  This is using es6 style getters and setters which are defined on the instance's prototype rather than the instance itself which prevents it from being enumerable.  This property needs to be enumerable so the es6 getters and setters were replaced with `Object.defineProperty` getters and setters.