### PR TITLE
Prepare for 2.0.0-alpha.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0-alpha.2] - 2022-03-17
+
+### Fixed
+
+- The `findById` and `findByIds` database features were returning empty string when a record was not found. However, the types for the responses were anticipating `null` to be returned in this scenario. The handling code was anticipating `null` and was returning an empty `Model` instance instead of returning `null` as expected. Use of `null` is a better pattern and the database code was adjusted to return `null` instead of empty string. ([#37](https://github.com/STORIS/mvom/pull/37))
+- The `unibasic` path for db server feature deployments was resolving to the incorrect file system location ([#37](https://github.com/STORIS/mvom/pull/37))
+- The `Document` and `Model` constructors were incorrectly only allowing an option of either `record` or `data` to be supplied. It is valid syntax to supply both so the restrictions on the constructor options were relaxed. ([#37](https://github.com/STORIS/mvom/pull/37))
+
 ## [2.0.0-alpha.1] - 2022-03-14
 
 ### Breaking Changes
@@ -321,7 +329,8 @@ We've graduated from Alpha to Beta! Semver has been updated so breaking vs. non-
 
 Initial alpha release of this library! Thanks for using it!
 
-[unreleased]: https://github.com/storis/mvom/compare/2.0.0-alpha.1...HEAD
+[unreleased]: https://github.com/storis/mvom/compare/2.0.0-alpha.2...HEAD
+[2.0.0-alpha.2]: https://github.com/storis/mvom/compare/2.0.0-alpha.1...2.0.0-alpha.2
 [2.0.0-alpha.1]: https://github.com/storis/mvom/compare/2.0.0-alpha.0...2.0.0-alpha.1
 [2.0.0-alpha.0]: https://github.com/storis/mvom/compare/1.0.0...2.0.0-alpha.0
 [1.0.0]: https://github.com/storis/mvom/compare/1.0.0-rc.1...1.0.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mvom",
-  "version": "2.0.0-alpha.1",
+  "version": "2.0.0-alpha.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mvom",
-      "version": "2.0.0-alpha.1",
+      "version": "2.0.0-alpha.2",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.26.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mvom",
   "private": true,
-  "version": "2.0.0-alpha.1",
+  "version": "2.0.0-alpha.2",
   "description": "Multivalue Object Mapper",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
This PR prepares for release `2.0.0-alpha.2` by updating the version and CHANGELOG.