### PR TITLE
Replace moment with date-fns

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "license": "MIT",
       "dependencies": {
         "axios": "^0.26.1",
+        "date-fns": "^2.28.0",
         "fs-extra": "^10.0.1",
         "lodash": "^4.17.21",
-        "moment": "^2.29.1",
         "semver": "^7.3.5"
       },
       "devDependencies": {
@@ -4099,6 +4099,18 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
+      "integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==",
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
       }
     },
     "node_modules/debug": {
@@ -8587,14 +8599,6 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
-    },
-    "node_modules/moment": {
-      "version": "2.29.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/ms": {
       "version": "2.1.2",
@@ -13583,6 +13587,11 @@
         "whatwg-url": "^8.0.0"
       }
     },
+    "date-fns": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
+      "integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw=="
+    },
     "debug": {
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
@@ -16899,11 +16908,6 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
-    },
-    "moment": {
-      "version": "2.29.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
     },
     "ms": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -45,9 +45,9 @@
   "license": "MIT",
   "dependencies": {
     "axios": "^0.26.1",
+    "date-fns": "^2.28.0",
     "fs-extra": "^10.0.1",
     "lodash": "^4.17.21",
-    "moment": "^2.29.1",
     "semver": "^7.3.5"
   },
   "devDependencies": {

--- a/src/constants/ISOCalendarDateFormat.ts
+++ b/src/constants/ISOCalendarDateFormat.ts
@@ -1,2 +1,2 @@
 /** External format for ISO Calendar Date data */
-export default 'YYYY-MM-DD';
+export default 'yyyy-MM-dd';

--- a/src/constants/ISOCalendarDateTimeFormat.ts
+++ b/src/constants/ISOCalendarDateTimeFormat.ts
@@ -1,2 +1,2 @@
 /** External format for ISO Calendar Date/Time data */
-export default 'YYYY-MM-DD[T]HH:mm:ss.SSS';
+export default "yyyy-MM-dd'T'HH:mm:ss.SSS";

--- a/src/constants/mvEpoch.ts
+++ b/src/constants/mvEpoch.ts
@@ -1,2 +1,2 @@
 /** The multivalue date epoch */
-export default '1967-12-31';
+export default new Date(1967, 11, 31);

--- a/src/schemaType/ISOCalendarDateType.ts
+++ b/src/schemaType/ISOCalendarDateType.ts
@@ -1,4 +1,4 @@
-import moment from 'moment';
+import { addDays, differenceInDays, format, isValid, parse } from 'date-fns';
 import { ISOCalendarDateFormat, mvEpoch } from '../constants';
 import { TransformDataError } from '../errors';
 import BaseDateType from './BaseDateType';
@@ -36,7 +36,7 @@ class ISOCalendarDateType extends BaseDateType {
 			});
 		}
 
-		return moment(mvEpoch).add(castValue, 'days').format(ISOCalendarDateFormat);
+		return format(addDays(mvEpoch, castValue), ISOCalendarDateFormat);
 	}
 
 	/**
@@ -57,7 +57,7 @@ class ISOCalendarDateType extends BaseDateType {
 			});
 		}
 
-		return String(moment(value).diff(moment(mvEpoch), 'days'));
+		return String(differenceInDays(this.parseISOCalendarDate(value), mvEpoch));
 	}
 
 	/** ISOCalendarDateType data type validator */
@@ -70,8 +70,13 @@ class ISOCalendarDateType extends BaseDateType {
 			return false;
 		}
 
-		return moment(value, ISOCalendarDateFormat).isValid();
+		return isValid(this.parseISOCalendarDate(value));
 	};
+
+	/** Parse ISOCalendarDate string into date */
+	private parseISOCalendarDate(value: string) {
+		return parse(value, ISOCalendarDateFormat, new Date());
+	}
 }
 
 export default ISOCalendarDateType;

--- a/src/schemaType/__tests__/ISOCalendarDateType.test.ts
+++ b/src/schemaType/__tests__/ISOCalendarDateType.test.ts
@@ -167,6 +167,20 @@ describe('validations', () => {
 			);
 		});
 
+		test('should return error message if value is an invalid date', async () => {
+			const definition: SchemaTypeDefinitionISOCalendarDate = {
+				type: 'ISOCalendarDate',
+				path: '2',
+			};
+			const isoCalendarDateType = new ISOCalendarDateType(definition);
+
+			const value = '2022-02-31'; // only 28 days in month
+
+			expect(await isoCalendarDateType.validate(value, documentMock)).toContain(
+				'Property cannot be cast into the defined type',
+			);
+		});
+
 		test('should not return error message if value is a properly formatted string', async () => {
 			const definition: SchemaTypeDefinitionISOCalendarDate = {
 				type: 'ISOCalendarDate',

--- a/src/schemaType/__tests__/ISOTimeType.test.ts
+++ b/src/schemaType/__tests__/ISOTimeType.test.ts
@@ -102,7 +102,9 @@ describe('transformToDb', () => {
 		};
 		const isoTimeType = new ISOTimeType(definition);
 
-		expect(isoTimeType.transformToDb(null)).toBeNull();
+		const value = null;
+
+		expect(isoTimeType.transformToDb(value)).toBeNull();
 	});
 
 	test('should throw TransformDataError if value is not a string', () => {
@@ -113,8 +115,25 @@ describe('transformToDb', () => {
 		};
 		const isoTimeType = new ISOTimeType(definition);
 
+		const value = 1234;
+
 		expect(() => {
-			isoTimeType.transformToDb(1234);
+			isoTimeType.transformToDb(value);
+		}).toThrow(TransformDataError);
+	});
+
+	test('should throw TransformDataError if value is an improperly formatted string', () => {
+		const definition: SchemaTypeDefinitionISOTime = {
+			type: 'ISOTime',
+			path: '1',
+			dbFormat: 's',
+		};
+		const isoTimeType = new ISOTimeType(definition);
+
+		const value = '13:14:15'; // missing milliseconds
+
+		expect(() => {
+			isoTimeType.transformToDb(value);
 		}).toThrow(TransformDataError);
 	});
 


### PR DESCRIPTION
This PR eliminates the `moment` dependency in favor of `date-fns`.  `moment` is a legacy project and is in maintenance mode and they recommend using a different library while `date-fns` is an active project.

Most places where `moment` was used previously have been replaced with comparable functions from `date-fns`.  An exception to this is in the `IsoTimeType` schema type formatters.  A separate bug was discovered where the math operation being used to convert to/from internal time to ISO time was working incorrectly on the date that a daylight savings time shift occurred.  This was because the previous calculation was relying on the difference between the start of the day and the value being converted.  On days where daylight savings time shifts, this caused the time to be off by +/- 1 hour.  To correct this problem, the calculation for converting to/from internal time was internalized.