### PR TITLE
Allow projection of only ids

### DIFF
--- a/src/Query.ts
+++ b/src/Query.ts
@@ -84,7 +84,7 @@ class Query<TSchema extends GenericObject = GenericObject> {
 	private readonly skip?: number | null;
 
 	/** Specify the projection attribute in result set */
-	private readonly projection: string[];
+	private readonly projection: string[] | null;
 
 	/** Number of conditions in the query */
 	private conditionCount = 0;
@@ -99,7 +99,7 @@ class Query<TSchema extends GenericObject = GenericObject> {
 		this.Model = Model;
 		this.limit = limit;
 		this.skip = skip;
-		this.projection = projection ?? [];
+		this.projection = projection ?? null;
 
 		this.selection = this.formatSelectionCriteria(selectionCriteria);
 		this.sortCriteria = sort;
@@ -119,7 +119,10 @@ class Query<TSchema extends GenericObject = GenericObject> {
 
 		await this.validateQuery(queryCommand);
 
-		const projection = this.Model.schema?.transformPathsToDbPositions(this.projection) ?? [];
+		const projection =
+			this.projection != null && this.Model.schema != null
+				? this.Model.schema.transformPathsToDbPositions(this.projection)
+				: null;
 
 		const executionOptions = {
 			filename: this.Model.file,

--- a/src/__tests__/Query.test.ts
+++ b/src/__tests__/Query.test.ts
@@ -179,7 +179,7 @@ describe('exec', () => {
 					'find',
 					{
 						filename,
-						projection: [],
+						projection: null,
 						queryCommand: expectedQuery,
 					},
 					undefined,
@@ -208,7 +208,7 @@ describe('exec', () => {
 					'find',
 					{
 						filename,
-						projection: [],
+						projection: null,
 						queryCommand: expectedQuery,
 					},
 					undefined,
@@ -239,7 +239,7 @@ describe('exec', () => {
 					'find',
 					{
 						filename,
-						projection: [],
+						projection: null,
 						queryCommand: expectedQuery,
 					},
 					undefined,
@@ -268,7 +268,7 @@ describe('exec', () => {
 					'find',
 					{
 						filename,
-						projection: [],
+						projection: null,
 						queryCommand: expectedQuery,
 					},
 					undefined,
@@ -297,7 +297,7 @@ describe('exec', () => {
 					'find',
 					{
 						filename,
-						projection: [],
+						projection: null,
 						queryCommand: expectedQuery,
 					},
 					undefined,
@@ -326,7 +326,7 @@ describe('exec', () => {
 					'find',
 					{
 						filename,
-						projection: [],
+						projection: null,
 						queryCommand: expectedQuery,
 					},
 					undefined,
@@ -354,7 +354,7 @@ describe('exec', () => {
 					'find',
 					{
 						filename,
-						projection: [],
+						projection: null,
 						queryCommand: expectedQuery,
 					},
 					undefined,
@@ -383,7 +383,7 @@ describe('exec', () => {
 					'find',
 					{
 						filename,
-						projection: [],
+						projection: null,
 						queryCommand: expectedQuery,
 					},
 					undefined,
@@ -412,7 +412,7 @@ describe('exec', () => {
 					'find',
 					{
 						filename,
-						projection: [],
+						projection: null,
 						queryCommand: expectedQuery,
 					},
 					undefined,
@@ -441,7 +441,7 @@ describe('exec', () => {
 					'find',
 					{
 						filename,
-						projection: [],
+						projection: null,
 						queryCommand: expectedQuery,
 					},
 					undefined,
@@ -470,7 +470,7 @@ describe('exec', () => {
 					'find',
 					{
 						filename,
-						projection: [],
+						projection: null,
 						queryCommand: expectedQuery,
 					},
 					undefined,
@@ -499,7 +499,7 @@ describe('exec', () => {
 					'find',
 					{
 						filename,
-						projection: [],
+						projection: null,
 						queryCommand: expectedQuery,
 					},
 					undefined,
@@ -528,7 +528,7 @@ describe('exec', () => {
 					'find',
 					{
 						filename,
-						projection: [],
+						projection: null,
 						queryCommand: expectedQuery,
 					},
 					undefined,
@@ -557,7 +557,7 @@ describe('exec', () => {
 					'find',
 					{
 						filename,
-						projection: [],
+						projection: null,
 						queryCommand: expectedQuery,
 					},
 					undefined,
@@ -586,7 +586,7 @@ describe('exec', () => {
 					'find',
 					{
 						filename,
-						projection: [],
+						projection: null,
 						queryCommand: expectedQuery,
 					},
 					undefined,
@@ -615,7 +615,7 @@ describe('exec', () => {
 					'find',
 					{
 						filename,
-						projection: [],
+						projection: null,
 						queryCommand: expectedQuery,
 					},
 					undefined,
@@ -640,7 +640,7 @@ describe('exec', () => {
 					'find',
 					{
 						filename,
-						projection: [],
+						projection: null,
 						queryCommand: expectedQuery,
 					},
 					undefined,
@@ -675,7 +675,7 @@ describe('exec', () => {
 						'find',
 						{
 							filename,
-							projection: [],
+							projection: null,
 							queryCommand: expectedQuery,
 						},
 						undefined,
@@ -721,7 +721,7 @@ describe('exec', () => {
 				'find',
 				{
 					filename,
-					projection: [],
+					projection: null,
 					queryCommand: expectedQuery,
 				},
 				undefined,
@@ -760,7 +760,7 @@ describe('exec', () => {
 				'find',
 				{
 					filename,
-					projection: [],
+					projection: null,
 					queryCommand: expectedQuery,
 				},
 				undefined,
@@ -799,7 +799,7 @@ describe('exec', () => {
 				'find',
 				{
 					filename,
-					projection: [],
+					projection: null,
 					queryCommand: expectedQuery,
 				},
 				undefined,
@@ -847,7 +847,7 @@ describe('exec', () => {
 				'find',
 				{
 					filename,
-					projection: [],
+					projection: null,
 					queryCommand: expectedQuery,
 				},
 				undefined,
@@ -889,7 +889,7 @@ describe('exec', () => {
 				'find',
 				{
 					filename,
-					projection: [],
+					projection: null,
 					queryCommand: expectedQuery,
 				},
 				undefined,
@@ -924,7 +924,7 @@ describe('exec', () => {
 				'find',
 				{
 					filename,
-					projection: [],
+					projection: null,
 					queryCommand: expectedQuery,
 				},
 				undefined,
@@ -959,7 +959,7 @@ describe('exec', () => {
 				'find',
 				{
 					filename,
-					projection: [],
+					projection: null,
 					queryCommand: expectedQuery,
 				},
 				undefined,
@@ -989,7 +989,7 @@ describe('exec', () => {
 				'find',
 				{
 					filename,
-					projection: [],
+					projection: null,
 					queryCommand: expectedQuery,
 				},
 				undefined,
@@ -1028,7 +1028,7 @@ describe('exec', () => {
 				'find',
 				{
 					filename,
-					projection: [],
+					projection: null,
 					queryCommand: expectedQuery,
 				},
 				undefined,
@@ -1057,7 +1057,7 @@ describe('exec', () => {
 				'find',
 				{
 					filename,
-					projection: [],
+					projection: null,
 					queryCommand: expectedQuery,
 				},
 				undefined,
@@ -1086,7 +1086,7 @@ describe('exec', () => {
 				'find',
 				{
 					filename,
-					projection: [],
+					projection: null,
 					queryCommand: expectedQuery,
 				},
 				undefined,
@@ -1122,7 +1122,7 @@ describe('exec', () => {
 				'find',
 				{
 					filename,
-					projection: [],
+					projection: null,
 					queryCommand: expectedQuery,
 				},
 				undefined,
@@ -1158,7 +1158,7 @@ describe('exec', () => {
 				'find',
 				{
 					filename,
-					projection: [],
+					projection: null,
 					queryCommand: expectedQuery,
 				},
 				undefined,
@@ -1194,7 +1194,7 @@ describe('exec', () => {
 				'find',
 				{
 					filename,
-					projection: [],
+					projection: null,
 					queryCommand: expectedQuery,
 				},
 				undefined,
@@ -1234,7 +1234,7 @@ describe('exec', () => {
 				'find',
 				{
 					filename,
-					projection: [],
+					projection: null,
 					queryCommand: expectedQuery,
 					skip,
 					limit,
@@ -1266,7 +1266,7 @@ describe('exec', () => {
 				'find',
 				{
 					filename,
-					projection: [],
+					projection: null,
 					queryCommand: expectedQuery,
 				},
 				{ userDefined },

--- a/src/__tests__/compileModel.test.ts
+++ b/src/__tests__/compileModel.test.ts
@@ -393,6 +393,32 @@ describe('findById', () => {
 			{ userDefined },
 		);
 	});
+
+	test('should provide projection if specified', async () => {
+		const Model = compileModel(connectionMock, schema, filename, mockDelimiters);
+
+		const id1 = 'id1';
+		const version1 = '1';
+		connectionMock.executeDbFeature.mockResolvedValue({
+			result: { _id: id1, __v: version1, record: '' },
+		});
+
+		const projection = ['prop2'];
+		const document = await Model.findById(id1, { projection });
+
+		expect(document).toBeInstanceOf(Model);
+		expect(document!._id).toBe(id1);
+		expect(document!.__v).toBe(version1);
+		expect(connectionMock.executeDbFeature).toHaveBeenCalledWith(
+			'findById',
+			{
+				filename,
+				id: id1,
+				projection: [2],
+			},
+			undefined,
+		);
+	});
 });
 
 describe('findByIds', () => {
@@ -527,6 +553,42 @@ describe('findByIds', () => {
 				projection: null,
 			},
 			{ userDefined },
+		);
+	});
+
+	test('should provide projection if specified', async () => {
+		const Model = compileModel(connectionMock, schema, filename, mockDelimiters);
+
+		const id1 = 'id1';
+		const version1 = '1';
+		const id2 = 'id2';
+		const version2 = '2';
+		connectionMock.executeDbFeature.mockResolvedValue({
+			result: [
+				{ _id: id1, __v: version1, record: '' },
+				{ _id: id2, __v: version2, record: '' },
+			],
+		});
+
+		const projection = ['prop2'];
+		const documents = await Model.findByIds([id1, id2], { projection });
+		documents.forEach((document) => {
+			expect(document).toBeInstanceOf(Model);
+		});
+
+		const [document1, document2] = documents;
+		expect(document1!._id).toBe(id1);
+		expect(document1!.__v).toBe(version1);
+		expect(document2!._id).toBe(id2);
+		expect(document2!.__v).toBe(version2);
+		expect(connectionMock.executeDbFeature).toHaveBeenCalledWith(
+			'findByIds',
+			{
+				filename,
+				ids: [id1, id2],
+				projection: [2],
+			},
+			undefined,
 		);
 	});
 });

--- a/src/__tests__/compileModel.test.ts
+++ b/src/__tests__/compileModel.test.ts
@@ -160,7 +160,7 @@ describe('find', () => {
 			'find',
 			{
 				filename,
-				projection: [],
+				projection: null,
 				queryCommand: `select ${filename}`,
 			},
 			undefined,
@@ -199,7 +199,7 @@ describe('find', () => {
 			'find',
 			{
 				filename,
-				projection: [],
+				projection: null,
 				queryCommand: `select ${filename}`,
 			},
 			{ userDefined },
@@ -246,7 +246,7 @@ describe('findAndCount', () => {
 			'find',
 			{
 				filename,
-				projection: [],
+				projection: null,
 				queryCommand: `select ${filename}`,
 			},
 			undefined,
@@ -286,7 +286,7 @@ describe('findAndCount', () => {
 			'find',
 			{
 				filename,
-				projection: [],
+				projection: null,
 				queryCommand: `select ${filename}`,
 			},
 			{ userDefined },
@@ -314,7 +314,7 @@ describe('findById', () => {
 			{
 				filename,
 				id: id1,
-				projection: [],
+				projection: null,
 			},
 			undefined,
 		);
@@ -338,7 +338,7 @@ describe('findById', () => {
 			{
 				filename,
 				id: id1,
-				projection: [],
+				projection: null,
 			},
 			undefined,
 		);
@@ -360,7 +360,7 @@ describe('findById', () => {
 			{
 				filename,
 				id: id1,
-				projection: [],
+				projection: null,
 			},
 			undefined,
 		);
@@ -388,7 +388,7 @@ describe('findById', () => {
 			{
 				filename,
 				id: id1,
-				projection: [],
+				projection: null,
 			},
 			{ userDefined },
 		);
@@ -425,7 +425,7 @@ describe('findByIds', () => {
 			{
 				filename,
 				ids: [id1, id2],
-				projection: [],
+				projection: null,
 			},
 			undefined,
 		);
@@ -459,7 +459,7 @@ describe('findByIds', () => {
 			{
 				filename,
 				ids: [id1, id2],
-				projection: [],
+				projection: null,
 			},
 			undefined,
 		);
@@ -486,7 +486,7 @@ describe('findByIds', () => {
 			{
 				filename,
 				ids: [id1, id2],
-				projection: [],
+				projection: null,
 			},
 			undefined,
 		);
@@ -524,7 +524,7 @@ describe('findByIds', () => {
 			{
 				filename,
 				ids: [id1, id2],
-				projection: [],
+				projection: null,
 			},
 			{ userDefined },
 		);

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,14 +1,14 @@
 {
   "dependencies": {
-    "deleteById": "^2.0.0",
+    "deleteById": "^3.0.0",
     "deploy": "^1.0.0",
     "entry": "^0.2.0",
-    "find": "^3.0.0",
-    "findById": "^3.0.0",
-    "findByIds": "^3.0.0",
+    "find": "^4.0.0",
+    "findById": "^4.0.0",
+    "findByIds": "^4.0.0",
     "readFileContentsById": "^1.0.0",
     "getServerInfo": "^1.2.0",
-    "save": "^2.0.0",
+    "save": "^3.0.0",
     "setup": "^1.1.0",
     "teardown": "^1.0.0"
   }

--- a/src/types/DbSubroutineInput.ts
+++ b/src/types/DbSubroutineInput.ts
@@ -37,19 +37,19 @@ export interface DbSubroutineOptionsDeploy {
 export interface DbSubroutineOptionsFind {
 	filename: string;
 	queryCommand: string;
-	projection: number[];
+	projection: number[] | null;
 }
 
 export interface DbSubroutineOptionsFindById {
 	filename: string;
 	id: string;
-	projection: number[];
+	projection: number[] | null;
 }
 
 export interface DbSubroutineOptionsFindByIds {
 	filename: string;
 	ids: string[];
-	projection: number[];
+	projection: number[] | null;
 }
 
 export interface DbSubroutineOptionsReadFileContentsById {

--- a/src/unibasicTemplates/deleteById.njk
+++ b/src/unibasicTemplates/deleteById.njk
@@ -40,8 +40,8 @@ end then
     go closeReleaseAndReturnFromSub
   end
 
-  * create emprty projection array
-  if udoCreate(UDO_ARRAY, projection) then
+  * create null projection
+  if udoCreate(UDO_NULL, projection) then
     call error_handler(ERROR_UDO, output)
     go closeReleaseAndReturnFromSub
   end

--- a/src/unibasicTemplates/findByIds.njk
+++ b/src/unibasicTemplates/findByIds.njk
@@ -17,12 +17,6 @@ if udoGetProperty(options, 'ids', recordIds, type) then
   go returnFromSub
 end
 
-* get the projections from the options
-if udoGetProperty(options, 'projection', projection, type) then
-  call error_handler(ERROR_MALFORMED_INPUT, output)
-  go returnFromSub
-end
-
 recordIdsCount = 0
 begin case
   case type ne UDO_ARRAY
@@ -35,6 +29,12 @@ end case
 
 * make sure the array of ids passed in wasn't empty
 if recordIdsCount eq 0 then
+  call error_handler(ERROR_MALFORMED_INPUT, output)
+  go returnFromSub
+end
+
+* get the projections from the options
+if udoGetProperty(options, 'projection', projection, type) then
   call error_handler(ERROR_MALFORMED_INPUT, output)
   go returnFromSub
 end

--- a/src/unibasicTemplates/partials/formatDocument.njk
+++ b/src/unibasicTemplates/partials/formatDocument.njk
@@ -6,21 +6,32 @@ subroutine format_document(record, recordId, projection, document, errorCode)
 
 errorCode = ''
 
-* get projection positions
+if udoGetType(projection, projectionType) then
+  errorCode = ERROR_UDO
+  go returnFromSub
+end
+
 projectionPositions = ''
-loop
-  statusCode = UDOArrayGetNextItem(projection, projectionPosition, type)
-  if statusCode eq UDO_ERROR then
-    * reach the end of the array
-    exit
-  end
-  if statusCode ne UDO_SUCCESS then
-    * any other possible error
-    errorCode = ERROR_UDO
-    go returnFromSub
-  end
-  projectionPositions<-1> = projectionPosition
-repeat
+useProjection = @false
+
+if projectionType eq UDO_ARRAY then
+  * get projection positions
+  useProjection = @true
+
+  loop
+    statusCode = UDOArrayGetNextItem(projection, projectionPosition, type)
+    if statusCode eq UDO_ERROR then
+      * reach the end of the array
+      exit
+    end
+    if statusCode ne UDO_SUCCESS then
+      * any other possible error
+      errorCode = ERROR_UDO
+      go returnFromSub
+    end
+    projectionPositions<-1> = projectionPosition
+  repeat
+end
 
 * create output document object
 if udoCreate(UDO_OBJECT, document) then
@@ -59,10 +70,9 @@ end else
   end
 end
 
-lastProjectionPosition = dcount(projectionPositions, @am)
-
-if (lastProjectionPosition > 0) then
+if useProjection then
   recordContents = ''
+  lastProjectionPosition = dcount(projectionPositions, @am)
   for position = 1 to lastProjectionPosition
     recordContents<position> = record<position>
   next position

--- a/src/unibasicTemplates/save.njk
+++ b/src/unibasicTemplates/save.njk
@@ -101,8 +101,8 @@ if fkValidationErrorCount > 0 then
   go closeReleaseAndReturnFromSub
 end
 
-* create empty projection array
-if udoCreate(UDO_ARRAY, projection) then
+* create null projection
+if udoCreate(UDO_NULL, projection) then
    call error_handler(ERROR_UDO, output)
    go closeAndReturnFromSub
 end


### PR DESCRIPTION
Currently, the behavior of the `projection` option (`find`, `findAndCount`, `findById`, `findByIds`) is such that if the consumer were to provide an empty array of projection values then the behavior would be identical to providing no projection option at all.  Only if there are one or more values in the `projection` array will projection change the output result

This behavior is unexpected as an empty projection array should indicate that nothing should be projected at all.  This change adjusts the behavior so that no _data_ will be projected if an empty array is provided for `projection`.  The `_id` and `__v` values will continue to be emitted from the db server, however, and will be valued in the resulting document.