### PR TITLE
Throw with original value instead of partially transformed value

### DIFF
--- a/src/dataTransformers/ISOCalendarDateDataTransformer.ts
+++ b/src/dataTransformers/ISOCalendarDateDataTransformer.ts
@@ -19,7 +19,7 @@ class ISOCalendarDateDataTransformer implements DataTransformer {
 		if (!Number.isInteger(castValue)) {
 			throw new TransformDataError({
 				transformClass: this.constructor.name,
-				transformValue: castValue,
+				transformValue: value,
 			});
 		}
 

--- a/src/dataTransformers/ISOTimeDataTransformer.ts
+++ b/src/dataTransformers/ISOTimeDataTransformer.ts
@@ -31,14 +31,14 @@ class ISOTimeDataTransformer implements DataTransformer {
 		if (!Number.isInteger(internalTime) || internalTime < 0) {
 			throw new TransformDataError({
 				transformClass: this.constructor.name,
-				transformValue: internalTime,
+				transformValue: value,
 			});
 		}
 
 		if (internalTime > 86400000 || (!this.isDbInMs && internalTime > 86400)) {
 			throw new TransformDataError({
 				transformClass: this.constructor.name,
-				transformValue: internalTime,
+				transformValue: value,
 			});
 		}
 

--- a/src/dataTransformers/NumberDataTransformer.ts
+++ b/src/dataTransformers/NumberDataTransformer.ts
@@ -31,7 +31,7 @@ class NumberDataTransformer implements DataTransformer {
 		if (!Number.isFinite(castValue)) {
 			throw new TransformDataError({
 				transformClass: this.constructor.name,
-				transformValue: castValue,
+				transformValue: value,
 			});
 		}
 


### PR DESCRIPTION
There are scenarios where the transformation of data from multivalue cannot be performed which results in a logging of a `TransformDataError`.  Several of these scenarios where this error is thrown are including the failed transformation value in the error.  This makes diagnosis of problems difficult.  For example, if a number can't be transformed and results in a `NaN` value, the `NaN` will be logged instead of the original value.

This PR changes those logs to record the value prior to any modification so tracing the origin can be easier.