### PR TITLE
Handle trailing slash in mvis uri more gracefully

### DIFF
--- a/src/Connection.ts
+++ b/src/Connection.ts
@@ -170,7 +170,10 @@ class Connection {
 		this.logger = logger;
 		this.cacheMaxAge = cacheMaxAge;
 
-		const baseURL = `${mvisUri}/${account}/subroutine/${Connection.getServerProgramName('entry')}`;
+		const baseURL = new URL(
+			`${account}/subroutine/${Connection.getServerProgramName('entry')}`,
+			mvisUri,
+		).toString();
 
 		this.axiosInstance = axios.create({
 			baseURL,

--- a/src/__tests__/Connection.test.ts
+++ b/src/__tests__/Connection.test.ts
@@ -72,7 +72,7 @@ describe('createConnection', () => {
 	test('should construct complete base url for calls to mvis', () => {
 		Connection.createConnection(mvisUri, account);
 
-		const expected = new RegExp(`^${mvisUri}/${account}/subroutine/mvom_entry@\\d.\\d.\\d$`);
+		const expected = new RegExp(`^${mvisUri}/${account}/subroutine/mvom_entry@\\d+.\\d+.\\d+$`);
 
 		expect(mockedAxios.create).toHaveBeenCalledWith(
 			expect.objectContaining({
@@ -84,7 +84,7 @@ describe('createConnection', () => {
 	test('should construct complete base url for calls to mvis if trailing slash added to mvisUri', () => {
 		Connection.createConnection(`${mvisUri}/`, account);
 
-		const expected = new RegExp(`^${mvisUri}/${account}/subroutine/mvom_entry@\\d.\\d.\\d$`);
+		const expected = new RegExp(`^${mvisUri}/${account}/subroutine/mvom_entry@\\d+.\\d+.\\d+$`);
 
 		expect(mockedAxios.create).toHaveBeenCalledWith(
 			expect.objectContaining({

--- a/src/__tests__/Connection.test.ts
+++ b/src/__tests__/Connection.test.ts
@@ -29,7 +29,7 @@ const mockedAxios = axios as jest.Mocked<typeof axios>;
 const mockedAxiosInstance = mock<AxiosInstance>();
 const mockedFs = fs as jest.Mocked<typeof fs>;
 
-const mvisUri = 'mvisUri';
+const mvisUri = 'http://foo.bar.com';
 const account = 'account';
 
 const fullFeatureOutput = Object.entries(serverDependencies).map(
@@ -69,10 +69,27 @@ describe('createConnection', () => {
 		expect(Connection.createConnection(mvisUri, account)).toBeInstanceOf(Connection);
 	});
 
-	test('should include mvisUri and account in base url', () => {
+	test('should construct complete base url for calls to mvis', () => {
 		Connection.createConnection(mvisUri, account);
+
+		const expected = new RegExp(`^${mvisUri}/${account}/subroutine/mvom_entry@\\d.\\d.\\d$`);
+
 		expect(mockedAxios.create).toHaveBeenCalledWith(
-			expect.objectContaining({ baseURL: expect.stringContaining(`${mvisUri}/${account}`) }),
+			expect.objectContaining({
+				baseURL: expect.stringMatching(expected),
+			}),
+		);
+	});
+
+	test('should construct complete base url for calls to mvis if trailing slash added to mvisUri', () => {
+		Connection.createConnection(`${mvisUri}/`, account);
+
+		const expected = new RegExp(`^${mvisUri}/${account}/subroutine/mvom_entry@\\d.\\d.\\d$`);
+
+		expect(mockedAxios.create).toHaveBeenCalledWith(
+			expect.objectContaining({
+				baseURL: expect.stringMatching(expected),
+			}),
 		);
 	});
 


### PR DESCRIPTION
Currently, if the client passes an `mvisUri` with a trailing slash, the generated `baseURL` for axios will end up with two slashes in it due to the use of templated strings to construct the `baseURL`.  This PR adjusts the logic so that the `baseURL` will be created using the `URL` constructor which will properly build the url with and without a trailing slash.