### PR TITLE
Remove @types/jest and modern option for fakeTimers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,6 @@
         "@storis/prettier-config": "1.0.0",
         "@storis/tsconfig": "1.0.0",
         "@types/fs-extra": "9.0.13",
-        "@types/jest": "27.5.2",
         "@types/jest-when": "3.5.0",
         "@types/lodash": "4.14.182",
         "@types/node": "16.11.38",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "@storis/prettier-config": "1.0.0",
     "@storis/tsconfig": "1.0.0",
     "@types/fs-extra": "9.0.13",
-    "@types/jest": "27.5.2",
     "@types/jest-when": "3.5.0",
     "@types/lodash": "4.14.182",
     "@types/node": "16.11.38",

--- a/src/__tests__/Connection.test.ts
+++ b/src/__tests__/Connection.test.ts
@@ -618,7 +618,7 @@ describe('executeDbFeature', () => {
 
 describe('getDbDate', () => {
 	beforeAll(() => {
-		jest.useFakeTimers('modern');
+		jest.useFakeTimers();
 	});
 
 	afterAll(() => {
@@ -706,7 +706,7 @@ describe('getDbDate', () => {
 
 describe('getDbDateTime', () => {
 	beforeAll(() => {
-		jest.useFakeTimers('modern');
+		jest.useFakeTimers();
 	});
 
 	afterAll(() => {
@@ -794,7 +794,7 @@ describe('getDbDateTime', () => {
 
 describe('getDbTime', () => {
 	beforeAll(() => {
-		jest.useFakeTimers('modern');
+		jest.useFakeTimers();
 	});
 
 	afterAll(() => {


### PR DESCRIPTION
#145 attempted to update `@types/jest` but encountered CI failures on typechecking.  Having seen that, I recalled that `jest` ships its own types now and use of `@types/jest` is no longer necessary.  This PR eliminates the `@types/jest` dependency and now jest's internal types are being used.

Additionally, as of [jest 27](https://jestjs.io/blog/2021/05/25/jest-27#flipping-defaults), modern timers are now the default.  I've updated the calls to `useFakeTimers` to no longer pass the `modern` flag.