### PR TITLE
Fix issues with "like" queries and connection URL without trailing slash

### DIFF
--- a/src/Connection.ts
+++ b/src/Connection.ts
@@ -170,10 +170,12 @@ class Connection {
 		this.logger = logger;
 		this.cacheMaxAge = cacheMaxAge;
 
-		const baseURL = new URL(
-			`${account}/subroutine/${Connection.getServerProgramName('entry')}`,
-			mvisUri,
-		).toString();
+		const url = new URL(mvisUri);
+		url.pathname = url.pathname.replace(
+			/\/?$/,
+			`/${account}/subroutine/${Connection.getServerProgramName('entry')}`,
+		);
+		const baseURL = url.toString();
 
 		this.axiosInstance = axios.create({
 			baseURL,

--- a/src/Query.ts
+++ b/src/Query.ts
@@ -197,11 +197,14 @@ class Query<TSchema extends GenericObject = GenericObject> {
 					case '$ne':
 						return this.formatCondition(queryProperty, '#', mvValue);
 					case '$contains':
-						return this.formatCondition(queryProperty, 'like', `...${mvValue}...`);
+						this.validateLikeCondition(mvValue);
+						return this.formatCondition(queryProperty, 'like', `...'${mvValue}'...`);
 					case '$startsWith':
-						return this.formatCondition(queryProperty, 'like', `${mvValue}...`);
+						this.validateLikeCondition(mvValue);
+						return this.formatCondition(queryProperty, 'like', `'${mvValue}'...`);
 					case '$endsWith':
-						return this.formatCondition(queryProperty, 'like', `...${mvValue}`);
+						this.validateLikeCondition(mvValue);
+						return this.formatCondition(queryProperty, 'like', `...'${mvValue}'`);
 					case '$in':
 						return this.formatConditionList(queryProperty, '=', mvValue, 'or');
 					case '$nin':
@@ -348,6 +351,18 @@ class Query<TSchema extends GenericObject = GenericObject> {
 				message:
 					'Query condition count exceeds maximum number of query conditions of database server',
 			});
+		}
+	}
+
+	/** Validate that a "like" condition does not contain quotes */
+	private validateLikeCondition(value: unknown): void {
+		const stringValue = String(value);
+
+		if (stringValue.includes(`'`) || stringValue.includes(`"`)) {
+			// cannot query if like condition has single or double quotes in it
+			throw new Error(
+				'$contains, $startsWith, and $endsWith queries cannot contain single or double quotes in the conditional value',
+			);
 		}
 	}
 }

--- a/src/__tests__/Connection.test.ts
+++ b/src/__tests__/Connection.test.ts
@@ -29,7 +29,7 @@ const mockedAxios = axios as jest.Mocked<typeof axios>;
 const mockedAxiosInstance = mock<AxiosInstance>();
 const mockedFs = fs as jest.Mocked<typeof fs>;
 
-const mvisUri = 'http://foo.bar.com';
+const mvisUri = 'http://foo.bar.com/mvis';
 const account = 'account';
 
 const fullFeatureOutput = Object.entries(serverDependencies).map(

--- a/src/__tests__/Query.test.ts
+++ b/src/__tests__/Query.test.ts
@@ -506,91 +506,232 @@ describe('exec', () => {
 				);
 			});
 
-			test('should construct and execute query with contains condition', async () => {
-				const propertyName = 'property-name';
-				const propertyValue = 'property-value';
-				const propertyDictionary = 'property-dictionary';
-				const selectionCritieria = {
-					[propertyName]: { $contains: propertyValue },
-				};
+			describe('contains condition', () => {
+				test('should construct and execute query with contains condition', async () => {
+					const propertyName = 'property-name';
+					const propertyValue = 'property-value';
+					const propertyDictionary = 'property-dictionary';
+					const selectionCritieria = {
+						[propertyName]: { $contains: propertyValue },
+					};
 
-				// @ts-expect-error: Overriding mock
-				ModelConstructorMock.schema!.dictPaths = new Map([
-					[propertyName, { dictionary: propertyDictionary, dataTransformer: dataTransformerMock }],
-				]);
+					// @ts-expect-error: Overriding mock
+					ModelConstructorMock.schema!.dictPaths = new Map([
+						[
+							propertyName,
+							{ dictionary: propertyDictionary, dataTransformer: dataTransformerMock },
+						],
+					]);
 
-				const query = new Query(ModelConstructorMock, selectionCritieria);
+					const query = new Query(ModelConstructorMock, selectionCritieria);
 
-				expect(await query.exec()).toEqual(dbQueryResult);
+					expect(await query.exec()).toEqual(dbQueryResult);
 
-				const expectedQuery = `select ${filename} with ${propertyDictionary} like "...${propertyValue}..."`;
-				expect(ModelConstructorMock.connection.executeDbFeature).toHaveBeenCalledWith(
-					'find',
-					{
-						filename,
-						projection: null,
-						queryCommand: expectedQuery,
-					},
-					undefined,
-				);
+					const expectedQuery = `select ${filename} with ${propertyDictionary} like "...'${propertyValue}'..."`;
+					expect(ModelConstructorMock.connection.executeDbFeature).toHaveBeenCalledWith(
+						'find',
+						{
+							filename,
+							projection: null,
+							queryCommand: expectedQuery,
+						},
+						undefined,
+					);
+				});
+
+				test('should throw error if contains condition contains double quote', () => {
+					const propertyName = 'property-name';
+					const propertyValue = 'property-value"';
+					const propertyDictionary = 'property-dictionary';
+					const selectionCritieria = {
+						[propertyName]: { $contains: propertyValue },
+					};
+
+					// @ts-expect-error: Overriding mock
+					ModelConstructorMock.schema!.dictPaths = new Map([
+						[
+							propertyName,
+							{ dictionary: propertyDictionary, dataTransformer: dataTransformerMock },
+						],
+					]);
+
+					expect(() => {
+						new Query(ModelConstructorMock, selectionCritieria);
+					}).toThrow();
+				});
+
+				test('should throw error if contains condition contains single quote', () => {
+					const propertyName = 'property-name';
+					const propertyValue = "property-value'";
+					const propertyDictionary = 'property-dictionary';
+					const selectionCritieria = {
+						[propertyName]: { $contains: propertyValue },
+					};
+
+					// @ts-expect-error: Overriding mock
+					ModelConstructorMock.schema!.dictPaths = new Map([
+						[
+							propertyName,
+							{ dictionary: propertyDictionary, dataTransformer: dataTransformerMock },
+						],
+					]);
+
+					expect(() => {
+						new Query(ModelConstructorMock, selectionCritieria);
+					}).toThrow();
+				});
 			});
 
-			test('should construct and execute query with startsWith condition', async () => {
-				const propertyName = 'property-name';
-				const propertyValue = 'property-value';
-				const propertyDictionary = 'property-dictionary';
-				const selectionCritieria = {
-					[propertyName]: { $startsWith: propertyValue },
-				};
+			describe('startsWith condition', () => {
+				test('should construct and execute query with startsWith condition', async () => {
+					const propertyName = 'property-name';
+					const propertyValue = 'property-value';
+					const propertyDictionary = 'property-dictionary';
+					const selectionCritieria = {
+						[propertyName]: { $startsWith: propertyValue },
+					};
 
-				// @ts-expect-error: Overriding mock
-				ModelConstructorMock.schema!.dictPaths = new Map([
-					[propertyName, { dictionary: propertyDictionary, dataTransformer: dataTransformerMock }],
-				]);
+					// @ts-expect-error: Overriding mock
+					ModelConstructorMock.schema!.dictPaths = new Map([
+						[
+							propertyName,
+							{ dictionary: propertyDictionary, dataTransformer: dataTransformerMock },
+						],
+					]);
 
-				const query = new Query(ModelConstructorMock, selectionCritieria);
+					const query = new Query(ModelConstructorMock, selectionCritieria);
 
-				expect(await query.exec()).toEqual(dbQueryResult);
+					expect(await query.exec()).toEqual(dbQueryResult);
 
-				const expectedQuery = `select ${filename} with ${propertyDictionary} like "${propertyValue}..."`;
-				expect(ModelConstructorMock.connection.executeDbFeature).toHaveBeenCalledWith(
-					'find',
-					{
-						filename,
-						projection: null,
-						queryCommand: expectedQuery,
-					},
-					undefined,
-				);
+					const expectedQuery = `select ${filename} with ${propertyDictionary} like "'${propertyValue}'..."`;
+					expect(ModelConstructorMock.connection.executeDbFeature).toHaveBeenCalledWith(
+						'find',
+						{
+							filename,
+							projection: null,
+							queryCommand: expectedQuery,
+						},
+						undefined,
+					);
+				});
+
+				test('should throw error if startsWith condition contains double quote', () => {
+					const propertyName = 'property-name';
+					const propertyValue = 'property-value"';
+					const propertyDictionary = 'property-dictionary';
+					const selectionCritieria = {
+						[propertyName]: { $startsWith: propertyValue },
+					};
+
+					// @ts-expect-error: Overriding mock
+					ModelConstructorMock.schema!.dictPaths = new Map([
+						[
+							propertyName,
+							{ dictionary: propertyDictionary, dataTransformer: dataTransformerMock },
+						],
+					]);
+
+					expect(() => {
+						new Query(ModelConstructorMock, selectionCritieria);
+					}).toThrow();
+				});
+
+				test('should throw error if startsWith condition contains single quote', () => {
+					const propertyName = 'property-name';
+					const propertyValue = "property-value'";
+					const propertyDictionary = 'property-dictionary';
+					const selectionCritieria = {
+						[propertyName]: { $startsWith: propertyValue },
+					};
+
+					// @ts-expect-error: Overriding mock
+					ModelConstructorMock.schema!.dictPaths = new Map([
+						[
+							propertyName,
+							{ dictionary: propertyDictionary, dataTransformer: dataTransformerMock },
+						],
+					]);
+
+					expect(() => {
+						new Query(ModelConstructorMock, selectionCritieria);
+					}).toThrow();
+				});
 			});
 
-			test('should construct and execute query with endsWith condition', async () => {
-				const propertyName = 'property-name';
-				const propertyValue = 'property-value';
-				const propertyDictionary = 'property-dictionary';
-				const selectionCritieria = {
-					[propertyName]: { $endsWith: propertyValue },
-				};
+			describe('endsWith condition', () => {
+				test('should construct and execute query with endsWith condition', async () => {
+					const propertyName = 'property-name';
+					const propertyValue = 'property-value';
+					const propertyDictionary = 'property-dictionary';
+					const selectionCritieria = {
+						[propertyName]: { $endsWith: propertyValue },
+					};
 
-				// @ts-expect-error: Overriding mock
-				ModelConstructorMock.schema!.dictPaths = new Map([
-					[propertyName, { dictionary: propertyDictionary, dataTransformer: dataTransformerMock }],
-				]);
+					// @ts-expect-error: Overriding mock
+					ModelConstructorMock.schema!.dictPaths = new Map([
+						[
+							propertyName,
+							{ dictionary: propertyDictionary, dataTransformer: dataTransformerMock },
+						],
+					]);
 
-				const query = new Query(ModelConstructorMock, selectionCritieria);
+					const query = new Query(ModelConstructorMock, selectionCritieria);
 
-				expect(await query.exec()).toEqual(dbQueryResult);
+					expect(await query.exec()).toEqual(dbQueryResult);
 
-				const expectedQuery = `select ${filename} with ${propertyDictionary} like "...${propertyValue}"`;
-				expect(ModelConstructorMock.connection.executeDbFeature).toHaveBeenCalledWith(
-					'find',
-					{
-						filename,
-						projection: null,
-						queryCommand: expectedQuery,
-					},
-					undefined,
-				);
+					const expectedQuery = `select ${filename} with ${propertyDictionary} like "...'${propertyValue}'"`;
+					expect(ModelConstructorMock.connection.executeDbFeature).toHaveBeenCalledWith(
+						'find',
+						{
+							filename,
+							projection: null,
+							queryCommand: expectedQuery,
+						},
+						undefined,
+					);
+				});
+
+				test('should throw error if endsWith condition contains double quote', () => {
+					const propertyName = 'property-name';
+					const propertyValue = 'property-value"';
+					const propertyDictionary = 'property-dictionary';
+					const selectionCritieria = {
+						[propertyName]: { $endsWith: propertyValue },
+					};
+
+					// @ts-expect-error: Overriding mock
+					ModelConstructorMock.schema!.dictPaths = new Map([
+						[
+							propertyName,
+							{ dictionary: propertyDictionary, dataTransformer: dataTransformerMock },
+						],
+					]);
+
+					expect(() => {
+						new Query(ModelConstructorMock, selectionCritieria);
+					}).toThrow();
+				});
+
+				test('should throw error if endsWith condition contains single quote', () => {
+					const propertyName = 'property-name';
+					const propertyValue = "property-value'";
+					const propertyDictionary = 'property-dictionary';
+					const selectionCritieria = {
+						[propertyName]: { $endsWith: propertyValue },
+					};
+
+					// @ts-expect-error: Overriding mock
+					ModelConstructorMock.schema!.dictPaths = new Map([
+						[
+							propertyName,
+							{ dictionary: propertyDictionary, dataTransformer: dataTransformerMock },
+						],
+					]);
+
+					expect(() => {
+						new Query(ModelConstructorMock, selectionCritieria);
+					}).toThrow();
+				});
 			});
 
 			test('should construct and execute query with not in condition', async () => {

--- a/website/docs/04 - Model/06 - Querying/02 - Query Operators.md
+++ b/website/docs/04 - Model/06 - Querying/02 - Query Operators.md
@@ -154,6 +154,10 @@ The query which will be executed on the MultiValue database is:
 select ITEM with DESCRIPTION like "...Bed..."
 ```
 
+:::caution
+Queries with the `$contains` operator cannot include single or double quotes (`'` or `"`) in the query constant value.
+:::
+
 ## Starts With Operator
 
 The starts with operator is `$startsWith`. This operator will find records where the property's value starts with the provided conditional value.
@@ -170,6 +174,10 @@ The query which will be executed on the MultiValue database is:
 select ITEM with DESCRIPTION like "Bed..."
 ```
 
+:::caution
+Queries with the `$startsWith` operator cannot include single or double quotes (`'` or `"`) in the query constant value.
+:::
+
 ## Ends With Operator
 
 The ends with operator is `$endsWith`. This operator will find records where the property's value ends with the provided conditional value.
@@ -185,6 +193,10 @@ The query which will be executed on the MultiValue database is:
 ```
 select ITEM with DESCRIPTION like "...Bed"
 ```
+
+:::caution
+Queries with the `$endsWith` operator cannot include single or double quotes (`'` or `"`) in the query constant value.
+:::
 
 ## In Operator
 


### PR DESCRIPTION
This PR fixes two distinct issues:

1. #128 introduced an issue where if a trailing slash was not provided for the mvis URI then the last part of the path was being lost.  For example, `http://example.com/part1/part2` would strip `part2` when constructing the full URL for calls to MVIS.
    - This PR changes the URL construction so a trailing slash is conditionally added to the URL when constructing the remaining parts of the full URL for calls to MVIS.
2. When performing `$contains`, `$startsWith`, or `$endsWith` queries, it was possible for matching records to not be found because of the potential that the query constant contained the pattern-matching syntax allowed by UniQuery.  With `LIKE` queries, UniQuery allows for pattern matching with formats of `nA` or `nN` to signify a number of numeric or alpha characters.  If the query constant happened to contain a number followed by `A` or `N` then the pattern matching would run.
    - This PR places the constant values in single quotes (as recommended by the UniQuery documentation) which bypasses the pattern matching in this case.
    - In order for this to work properly, LIKE queries are now prohibited from containing single or double quotes.  The documentation was updated to reflect this.