### PR TITLE
Fix documentation version link

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -74,7 +74,7 @@ const config = {
 					},
 					{
 						type: 'docsVersion',
-						label: '2.0.0-alpha.6',
+						label: '2.0.0-alpha.7',
 						position: 'right',
 					},
 					{


### PR DESCRIPTION
When `2.0.0-alpha.7` was released, the documentation link to the version was not fully updated.  This PR updates that link.