### PR TITLE
Add filename and recordId property to all relevant errors

### DIFF
--- a/src/Connection.ts
+++ b/src/Connection.ts
@@ -31,6 +31,7 @@ import type {
 	DbServerDelimiters,
 	DbServerLimits,
 	DbSubroutineInputOptionsMap,
+	DbSubroutineInputSave,
 	DbSubroutineOutputErrorForeignKey,
 	DbSubroutinePayload,
 	DbSubroutineResponseError,
@@ -246,7 +247,7 @@ class Connection {
 			return axios.isAxiosError(err) ? this.handleAxiosError(err) : this.handleUnexpectedError(err);
 		}
 
-		this.handleDbServerError(response);
+		this.handleDbServerError(response, subroutineName, options);
 
 		// return the relevant portion from the db server response
 		return response.data.output;
@@ -324,33 +325,57 @@ class Connection {
 	 * @throws {@link RecordVersionError} A record changed between being read and written and could not be updated
 	 * @throws {@link DbServerError} An error was encountered on the database server
 	 */
-	private handleDbServerError<TResponse extends DbSubroutineResponseTypes>(
+	private handleDbServerError<
+		TResponse extends DbSubroutineResponseTypes,
+		TSubroutineName extends keyof (DbSubroutineInputOptionsMap & DbSubroutineResponseTypesMap),
+	>(
 		response: AxiosResponse<TResponse | DbSubroutineResponseError>,
+		subroutineName: TSubroutineName,
+		options: DbSubroutineInputOptionsMap[TSubroutineName],
 	): asserts response is AxiosResponse<TResponse> {
 		if (response.data.output == null) {
 			// handle invalid response
-			this.logHandler.error('Response from db server was malformed');
-			throw new DbServerError({ message: 'Response from db server was malformed' });
+			this.logHandler.error(`Response from db server was malformed when calling ${subroutineName}`);
+			throw new DbServerError({
+				message: `Response from db server was malformed when calling ${subroutineName}`,
+			});
 		}
 
 		if ('errorCode' in response.data.output) {
 			const errorCode = Number(response.data.output.errorCode);
 			switch (errorCode) {
-				case dbErrors.foreignKeyValidation.code:
-					this.logHandler.debug('foreign key violations found when saving record');
+				case dbErrors.foreignKeyValidation.code: {
+					const { filename, id } = options as DbSubroutineInputSave;
+					this.logHandler.debug(
+						`foreign key violations found when saving record ${id} to ${filename}`,
+					);
 					throw new ForeignKeyValidationError({
 						foreignKeyValidationErrors: (response.data.output as DbSubroutineOutputErrorForeignKey)
 							.foreignKeyValidationErrors,
+						filename,
+						recordId: id,
 					});
-				case dbErrors.recordLocked.code:
-					this.logHandler.debug('record locked when saving record');
-					throw new RecordLockedError();
-				case dbErrors.recordVersion.code:
-					this.logHandler.debug('record version mismatch found when saving record');
-					throw new RecordVersionError();
+				}
+				case dbErrors.recordLocked.code: {
+					// We could receive a record locked error from a delete as well but both option types have a filename and id
+					const { filename, id } = options as DbSubroutineInputSave;
+					if (subroutineName === 'deleteById') {
+						this.logHandler.debug(`record locked when deleting record ${id} from ${filename}`);
+					} else {
+						this.logHandler.debug(`record locked when saving record ${id} to ${filename}`);
+					}
+					throw new RecordLockedError({ filename, recordId: id });
+				}
+				case dbErrors.recordVersion.code: {
+					const { filename, id } = options as DbSubroutineInputSave;
+					this.logHandler.debug(
+						`record version mismatch found when saving record ${id} to ${filename}`,
+					);
+					throw new RecordVersionError({ filename, recordId: id });
+				}
 				default:
 					this.logHandler.error(
-						`error code ${response.data.output.errorCode} occurred in database operation`,
+						`error code ${response.data.output.errorCode} occurred in database operation when calling ${subroutineName}`,
 					);
 					throw new DbServerError({ errorCode: response.data.output.errorCode });
 			}

--- a/src/compileModel.ts
+++ b/src/compileModel.ts
@@ -279,7 +279,11 @@ const compileModel = <TSchema extends GenericObject = GenericObject>(
 			// validate data prior to saving
 			const validationErrors = await this.validate();
 			if (validationErrors.size > 0) {
-				throw new DataValidationError({ validationErrors });
+				throw new DataValidationError({
+					validationErrors,
+					filename: Model.file,
+					recordId: this._id,
+				});
 			}
 
 			try {

--- a/src/errors/DataValidationError.ts
+++ b/src/errors/DataValidationError.ts
@@ -3,6 +3,8 @@ import BaseError from './BaseError';
 interface DataValidationErrorConstructorOptions {
 	message?: string;
 	validationErrors: Map<string, string | string[]>;
+	filename: string;
+	recordId: string;
 }
 
 /** Error thrown when a data validation fails when saving a document */
@@ -10,14 +12,22 @@ class DataValidationError extends BaseError {
 	/** Object containing details of validation errors */
 	public readonly validationErrors: Record<string, string | string[]>;
 
+	public readonly filename: string;
+
+	public readonly recordId: string;
+
 	public constructor({
 		message = 'Error(s) found while validating data',
 		validationErrors,
+		filename,
+		recordId,
 	}: DataValidationErrorConstructorOptions) {
 		const name = 'DataValidationError';
 		super(message, name);
 
 		this.validationErrors = Object.fromEntries(validationErrors);
+		this.filename = filename;
+		this.recordId = recordId;
 	}
 }
 

--- a/src/errors/ForeignKeyValidationError.ts
+++ b/src/errors/ForeignKeyValidationError.ts
@@ -8,6 +8,8 @@ export interface ForeignKeyValidationErrorData {
 interface ForeignKeyValidationErrorConstructorOptions {
 	message?: string;
 	foreignKeyValidationErrors: ForeignKeyValidationErrorData[];
+	filename: string;
+	recordId: string;
 }
 
 /** Error thrown when foreign key violations encountered when saving a document */
@@ -15,14 +17,22 @@ class ForeignKeyValidationError extends BaseError {
 	/** Object containing details of validation errors */
 	public readonly foreignKeyValidationErrors: ForeignKeyValidationErrorData[];
 
+	public readonly filename: string;
+
+	public readonly recordId: string;
+
 	public constructor({
 		message = 'Foreign key violation(s) encountered while saving',
 		foreignKeyValidationErrors,
+		filename,
+		recordId,
 	}: ForeignKeyValidationErrorConstructorOptions) {
 		const name = 'ForeignKeyValidationError';
 		super(message, name);
 
 		this.foreignKeyValidationErrors = foreignKeyValidationErrors;
+		this.filename = filename;
+		this.recordId = recordId;
 	}
 }
 

--- a/src/errors/RecordLockedError.ts
+++ b/src/errors/RecordLockedError.ts
@@ -2,15 +2,26 @@ import BaseError from './BaseError';
 
 interface RecordLockedErrorConstructorOptions {
 	message?: string;
+	filename: string;
+	recordId: string;
 }
 
 /** Error thrown when an error occurs due to a record being locked which prevented update */
 class RecordLockedError extends BaseError {
+	public readonly filename: string;
+
+	public readonly recordId: string;
+
 	public constructor({
 		message = 'Record is locked and cannot be updated',
-	}: RecordLockedErrorConstructorOptions = {}) {
+		filename,
+		recordId,
+	}: RecordLockedErrorConstructorOptions) {
 		const name = 'RecordLockedError';
 		super(message, name);
+
+		this.filename = filename;
+		this.recordId = recordId;
 	}
 }
 

--- a/src/errors/RecordVersionError.ts
+++ b/src/errors/RecordVersionError.ts
@@ -2,15 +2,26 @@ import BaseError from './BaseError';
 
 interface RecordVersionErrorConstructorOptions {
 	message?: string;
+	filename: string;
+	recordId: string;
 }
 
 /** Error thrown when an error occurs due to a record having changed since it was read which prevented update */
 class RecordVersionError extends BaseError {
+	public readonly filename: string;
+
+	public readonly recordId: string;
+
 	public constructor({
 		message = 'Record has changed since it was read and cannot be updated',
-	}: RecordVersionErrorConstructorOptions = {}) {
+		filename,
+		recordId,
+	}: RecordVersionErrorConstructorOptions) {
 		const name = 'RecordVersionError';
 		super(message, name);
+
+		this.filename = filename;
+		this.recordId = recordId;
 	}
 }
 

--- a/src/errors/__tests__/DataValidationError.test.ts
+++ b/src/errors/__tests__/DataValidationError.test.ts
@@ -1,13 +1,17 @@
 import DataValidationError from '../DataValidationError';
 
 const validationErrors = new Map([['foo', 'foo']]);
+const filename = 'filename';
+const recordId = 'recordId';
 
 test('should instantiate error with expected instance properties', (): void => {
-	const error = new DataValidationError({ validationErrors });
+	const error = new DataValidationError({ validationErrors, filename, recordId });
 	const expected = {
 		name: 'DataValidationError',
 		message: 'Error(s) found while validating data',
 		validationErrors,
+		filename,
+		recordId,
 	};
 	expect(error).toMatchObject(expected);
 });
@@ -17,6 +21,8 @@ test('should allow for override of message', (): void => {
 	const error = new DataValidationError({
 		message,
 		validationErrors,
+		filename,
+		recordId,
 	});
 	expect(error.message).toEqual(message);
 });

--- a/src/errors/__tests__/ForeignKeyValidationError.test.ts
+++ b/src/errors/__tests__/ForeignKeyValidationError.test.ts
@@ -1,13 +1,17 @@
 import ForeignKeyValidationError from '../ForeignKeyValidationError';
 
 const foreignKeyValidationErrors = [{ entityName: 'entityName', entityId: 'entityId' }];
+const filename = 'filename';
+const recordId = 'recordId';
 
 test('should instantiate error with expected instance properties', (): void => {
-	const error = new ForeignKeyValidationError({ foreignKeyValidationErrors });
+	const error = new ForeignKeyValidationError({ foreignKeyValidationErrors, filename, recordId });
 	const expected = {
 		name: 'ForeignKeyValidationError',
 		message: 'Foreign key violation(s) encountered while saving',
 		foreignKeyValidationErrors,
+		filename,
+		recordId,
 	};
 	expect(error).toMatchObject(expected);
 });
@@ -17,6 +21,8 @@ test('should allow for override of message', (): void => {
 	const error = new ForeignKeyValidationError({
 		message,
 		foreignKeyValidationErrors,
+		filename,
+		recordId,
 	});
 	expect(error.message).toEqual(message);
 });

--- a/src/errors/__tests__/RecordLockedError.test.ts
+++ b/src/errors/__tests__/RecordLockedError.test.ts
@@ -1,10 +1,15 @@
 import RecordLockedError from '../RecordLockedError';
 
+const filename = 'filename';
+const recordId = 'recordId';
+
 test('should instantiate error with expected instance properties', (): void => {
-	const error = new RecordLockedError();
+	const error = new RecordLockedError({ filename, recordId });
 	const expected = {
 		name: 'RecordLockedError',
 		message: 'Record is locked and cannot be updated',
+		filename,
+		recordId,
 	};
 	expect(error).toMatchObject(expected);
 });
@@ -13,6 +18,8 @@ test('should allow for override of message', (): void => {
 	const message = 'foo';
 	const error = new RecordLockedError({
 		message,
+		filename,
+		recordId,
 	});
 	expect(error.message).toEqual(message);
 });

--- a/src/errors/__tests__/RecordVersionError.test.ts
+++ b/src/errors/__tests__/RecordVersionError.test.ts
@@ -1,10 +1,15 @@
 import RecordVersionError from '../RecordVersionError';
 
+const filename = 'filename';
+const recordId = 'recordId';
+
 test('should instantiate error with expected instance properties', (): void => {
-	const error = new RecordVersionError();
+	const error = new RecordVersionError({ filename, recordId });
 	const expected = {
 		name: 'RecordVersionError',
 		message: 'Record has changed since it was read and cannot be updated',
+		filename,
+		recordId,
 	};
 	expect(error).toMatchObject(expected);
 });
@@ -13,6 +18,8 @@ test('should allow for override of message', (): void => {
 	const message = 'foo';
 	const error = new RecordVersionError({
 		message,
+		filename,
+		recordId,
 	});
 	expect(error.message).toEqual(message);
 });


### PR DESCRIPTION
This PR adds the filename and record id to any database mutation specific errors. These include

- DataValidationError (save)
- ForeignKeyValidationError (save)
- RecordLockedError (save/delete)
- RecordVersionError (save)

In addition I added the subroutine name to the generic error and added the filename/record id to any debug logs emitted in the error handler. I originally thought it would be a good idea to log the entire options object but decided not to because during a save it may contain sensitive data that we do not want to end up in a log.