### PR TITLE
CXM-5221/Pass request id from services

### DIFF
--- a/src/Connection.ts
+++ b/src/Connection.ts
@@ -289,7 +289,7 @@ class Connection {
 			);
 		}
 
-		const updatedSetupOptions = { ...setupOptions, maxReturnPayloadSize, requestId };
+		const updatedSetupOptions = { ...setupOptions, maxReturnPayloadSize };
 
 		this.logHandler.debug(`executing database subroutine "${subroutineName}"`);
 

--- a/src/Connection.ts
+++ b/src/Connection.ts
@@ -359,7 +359,7 @@ class Connection {
 	}
 
 	/** Get the db server information (date, time, etc.) */
-	private async getDbServerInfo({ requestId }: DbServerInfoOptions): Promise<ServerInfo> {
+	private async getDbServerInfo({ requestId }: DbServerInfoOptions = {}): Promise<ServerInfo> {
 		// set a mutex on acquiring server information so multiple simultaneous requests are not modifying the cache
 		return this.serverInfoMutex.runExclusive(async () => {
 			if (this.dbServerInfo == null || Date.now() > this.dbServerInfo.cacheExpiry) {

--- a/src/Connection.ts
+++ b/src/Connection.ts
@@ -98,7 +98,7 @@ interface ServerInfo {
 }
 
 interface RequestOptions {
-	requestId?: string | null;
+	requestId?: string;
 }
 
 export type OpenOptions = RequestOptions;

--- a/src/Connection.ts
+++ b/src/Connection.ts
@@ -320,24 +320,28 @@ class Connection {
 	}
 
 	/** Get the current ISOCalendarDate from the database */
+	/* istanbul ignore next: Optional parameter is covered by executeDbSubroutine test "should generate requestID if not provided" */
 	public async getDbDate({ requestId }: GetDbDateOptions = {}): Promise<string> {
 		const { timeDrift } = await this.getDbServerInfo({ requestId });
 		return format(addMilliseconds(Date.now(), timeDrift), ISOCalendarDateFormat);
 	}
 
 	/** Get the current ISOCalendarDateTime from the database */
+	/* istanbul ignore next: Optional parameter is covered by executeDbSubroutine test "should generate requestID if not provided" */
 	public async getDbDateTime({ requestId }: GetDbDateTimeOptions = {}): Promise<string> {
 		const { timeDrift } = await this.getDbServerInfo({ requestId });
 		return format(addMilliseconds(Date.now(), timeDrift), ISOCalendarDateTimeFormat);
 	}
 
 	/** Get the current ISOTime from the database */
+	/* istanbul ignore next: Optional parameter is covered by executeDbSubroutine test "should generate requestID if not provided" */
 	public async getDbTime({ requestId }: GetDbTimeOptions = {}): Promise<string> {
 		const { timeDrift } = await this.getDbServerInfo({ requestId });
 		return format(addMilliseconds(Date.now(), timeDrift), ISOTimeFormat);
 	}
 
 	/** Get the multivalue database server limits */
+	/* istanbul ignore next: Optional parameter is covered by executeDbSubroutine test "should generate requestID if not provided" */
 	public async getDbLimits({ requestId }: GetDbLimitsOptions = {}): Promise<DbServerLimits> {
 		const { limits } = await this.getDbServerInfo({ requestId });
 		return limits;
@@ -359,6 +363,7 @@ class Connection {
 	}
 
 	/** Get the db server information (date, time, etc.) */
+	/* istanbul ignore next: Optional parameter is covered by executeDbSubroutine test "should generate requestID if not provided" */
 	private async getDbServerInfo({ requestId }: DbServerInfoOptions = {}): Promise<ServerInfo> {
 		// set a mutex on acquiring server information so multiple simultaneous requests are not modifying the cache
 		return this.serverInfoMutex.runExclusive(async () => {

--- a/src/Connection.ts
+++ b/src/Connection.ts
@@ -1,3 +1,4 @@
+import crypto from 'crypto';
 import type http from 'http';
 import type https from 'https';
 import { Mutex } from 'async-mutex';
@@ -95,6 +96,22 @@ interface ServerInfo {
 	/** Multivalue database server limits */
 	limits: DbServerLimits;
 }
+
+interface RequestOptions {
+	requestId?: string | null;
+}
+
+export type OpenOptions = RequestOptions;
+
+export type DbServerInfoOptions = RequestOptions;
+
+export type GetDbDateOptions = RequestOptions;
+
+export type GetDbDateTimeOptions = RequestOptions;
+
+export type GetDbTimeOptions = RequestOptions;
+
+export type GetDbLimitsOptions = RequestOptions;
 // #endregion
 
 /** A connection object */
@@ -214,7 +231,7 @@ class Connection {
 	}
 
 	/** Open a database connection */
-	public async open(): Promise<void> {
+	public async open({ requestId }: OpenOptions = {}): Promise<void> {
 		if (this.status !== ConnectionStatus.disconnected) {
 			this.logHandler.error('Connection is not closed');
 			throw new ConnectionError({ message: 'Connection is not closed' });
@@ -234,7 +251,7 @@ class Connection {
 
 		this.status = ConnectionStatus.connected;
 
-		await this.getDbServerInfo(); // establish baseline for database server information
+		await this.getDbServerInfo({ requestId }); // establish baseline for database server information
 
 		this.logHandler.info('connection opened');
 	}
@@ -261,7 +278,8 @@ class Connection {
 				'Cannot execute database features until database connection has been established',
 			);
 		}
-		const { maxReturnPayloadSize = this.maxReturnPayloadSize } = setupOptions;
+		const { maxReturnPayloadSize = this.maxReturnPayloadSize, requestId = crypto.randomUUID() } =
+			setupOptions;
 		if (maxReturnPayloadSize < 0) {
 			this.logHandler.error(
 				`Maximum returned payload size of ${maxReturnPayloadSize} is invalid. Must be a positive integer`,
@@ -271,7 +289,7 @@ class Connection {
 			);
 		}
 
-		const updatedSetupOptions = { ...setupOptions, maxReturnPayloadSize };
+		const updatedSetupOptions = { ...setupOptions, maxReturnPayloadSize, requestId };
 
 		this.logHandler.debug(`executing database subroutine "${subroutineName}"`);
 
@@ -286,7 +304,11 @@ class Connection {
 		try {
 			response = await this.axiosInstance.post<
 				DbSubroutineResponseTypes | DbSubroutineResponseError
-			>(this.deploymentManager.subroutineName, { input: data });
+			>(
+				this.deploymentManager.subroutineName,
+				{ input: data },
+				{ headers: { 'X-MVIS-Trace-Id': requestId } },
+			);
 		} catch (err) {
 			return axios.isAxiosError(err) ? this.handleAxiosError(err) : this.handleUnexpectedError(err);
 		}
@@ -298,26 +320,26 @@ class Connection {
 	}
 
 	/** Get the current ISOCalendarDate from the database */
-	public async getDbDate(): Promise<string> {
-		const { timeDrift } = await this.getDbServerInfo();
+	public async getDbDate({ requestId }: GetDbDateOptions = {}): Promise<string> {
+		const { timeDrift } = await this.getDbServerInfo({ requestId });
 		return format(addMilliseconds(Date.now(), timeDrift), ISOCalendarDateFormat);
 	}
 
 	/** Get the current ISOCalendarDateTime from the database */
-	public async getDbDateTime(): Promise<string> {
-		const { timeDrift } = await this.getDbServerInfo();
+	public async getDbDateTime({ requestId }: GetDbDateTimeOptions = {}): Promise<string> {
+		const { timeDrift } = await this.getDbServerInfo({ requestId });
 		return format(addMilliseconds(Date.now(), timeDrift), ISOCalendarDateTimeFormat);
 	}
 
 	/** Get the current ISOTime from the database */
-	public async getDbTime(): Promise<string> {
-		const { timeDrift } = await this.getDbServerInfo();
+	public async getDbTime({ requestId }: GetDbTimeOptions = {}): Promise<string> {
+		const { timeDrift } = await this.getDbServerInfo({ requestId });
 		return format(addMilliseconds(Date.now(), timeDrift), ISOTimeFormat);
 	}
 
 	/** Get the multivalue database server limits */
-	public async getDbLimits(): Promise<DbServerLimits> {
-		const { limits } = await this.getDbServerInfo();
+	public async getDbLimits({ requestId }: GetDbLimitsOptions = {}): Promise<DbServerLimits> {
+		const { limits } = await this.getDbServerInfo({ requestId });
 		return limits;
 	}
 
@@ -337,7 +359,7 @@ class Connection {
 	}
 
 	/** Get the db server information (date, time, etc.) */
-	private async getDbServerInfo(): Promise<ServerInfo> {
+	private async getDbServerInfo({ requestId }: DbServerInfoOptions): Promise<ServerInfo> {
 		// set a mutex on acquiring server information so multiple simultaneous requests are not modifying the cache
 		return this.serverInfoMutex.runExclusive(async () => {
 			if (this.dbServerInfo == null || Date.now() > this.dbServerInfo.cacheExpiry) {
@@ -345,6 +367,7 @@ class Connection {
 				const { date, time, delimiters, limits } = await this.executeDbSubroutine(
 					'getServerInfo',
 					{},
+					{ ...(requestId && { requestId }) },
 				);
 
 				const timeDrift = differenceInMilliseconds(

--- a/src/__tests__/Connection.test.ts
+++ b/src/__tests__/Connection.test.ts
@@ -36,6 +36,7 @@ const mvisAdminUrl = 'http://foo.bar.com/mvisAdmin';
 const mvisAdminUsername = 'username';
 const mvisAdminPassword = 'password';
 const account = 'account';
+const requestId = 'requestId';
 
 beforeEach(() => {
 	mockedAxios.create.mockReturnValue(mockedAxiosInstance);
@@ -218,7 +219,7 @@ describe('open', () => {
 
 		connection.status = ConnectionStatus.connecting;
 
-		await expect(connection.open()).rejects.toThrow(ConnectionError);
+		await expect(connection.open({ requestId })).rejects.toThrow(ConnectionError);
 	});
 
 	test('should throw InvalidServerFeaturesError if database features are missing', async () => {
@@ -232,7 +233,7 @@ describe('open', () => {
 			account,
 		);
 
-		await expect(connection.open()).rejects.toThrow(InvalidServerFeaturesError);
+		await expect(connection.open({ requestId })).rejects.toThrow(InvalidServerFeaturesError);
 	});
 
 	test('should open new connection', async () => {
@@ -266,7 +267,7 @@ describe('open', () => {
 			account,
 		);
 
-		await connection.open();
+		await connection.open({ requestId });
 		expect(connection.status).toBe(ConnectionStatus.connected);
 	});
 });
@@ -361,7 +362,7 @@ describe('executeDbSubroutine', () => {
 			account,
 		);
 
-		await connection.open();
+		await connection.open({ requestId });
 
 		const filename = 'filename';
 		const id = 'id';
@@ -398,7 +399,7 @@ describe('executeDbSubroutine', () => {
 			mvisAdminPassword,
 			account,
 		);
-		await connection.open();
+		await connection.open({ requestId });
 
 		const filename = 'filename';
 		const id = 'id';
@@ -435,7 +436,7 @@ describe('executeDbSubroutine', () => {
 			mvisAdminPassword,
 			account,
 		);
-		await connection.open();
+		await connection.open({ requestId });
 
 		const filename = 'filename';
 		const id = 'id';
@@ -472,7 +473,7 @@ describe('executeDbSubroutine', () => {
 			mvisAdminPassword,
 			account,
 		);
-		await connection.open();
+		await connection.open({ requestId });
 
 		const filename = 'filename';
 		const id = 'id';
@@ -509,7 +510,7 @@ describe('executeDbSubroutine', () => {
 			mvisAdminPassword,
 			account,
 		);
-		await connection.open();
+		await connection.open({ requestId });
 
 		const filename = 'filename';
 		const id = 'id';
@@ -544,7 +545,7 @@ describe('executeDbSubroutine', () => {
 			mvisAdminPassword,
 			account,
 		);
-		await connection.open();
+		await connection.open({ requestId });
 
 		const filename = 'filename';
 		const id = 'id';
@@ -581,7 +582,7 @@ describe('executeDbSubroutine', () => {
 			mvisAdminPassword,
 			account,
 		);
-		await connection.open();
+		await connection.open({ requestId });
 
 		const filename = 'filename';
 		const id = 'id';
@@ -618,7 +619,7 @@ describe('executeDbSubroutine', () => {
 			mvisAdminPassword,
 			account,
 		);
-		await connection.open();
+		await connection.open({ requestId });
 
 		const filename = 'filename';
 		const id = 'id';
@@ -653,7 +654,7 @@ describe('executeDbSubroutine', () => {
 			mvisAdminPassword,
 			account,
 		);
-		await connection.open();
+		await connection.open({ requestId });
 
 		const filename = 'filename';
 		const id = 'id';
@@ -689,7 +690,7 @@ describe('executeDbSubroutine', () => {
 			mvisAdminPassword,
 			account,
 		);
-		await connection.open();
+		await connection.open({ requestId });
 
 		const filename = 'filename';
 		const id = 'id';
@@ -725,7 +726,7 @@ describe('executeDbSubroutine', () => {
 			mvisAdminPassword,
 			account,
 		);
-		await connection.open();
+		await connection.open({ requestId });
 
 		const filename = 'filename';
 		const id = 'id';
@@ -760,7 +761,7 @@ describe('executeDbSubroutine', () => {
 			mvisAdminPassword,
 			account,
 		);
-		await connection.open();
+		await connection.open({ requestId });
 
 		const filename = 'filename';
 		const id = 'id';
@@ -818,10 +819,10 @@ describe('getDbDate', () => {
 			mvisAdminPassword,
 			account,
 		);
-		await connection.open();
+		await connection.open({ requestId });
 
 		const expected = '2022-03-08';
-		expect(await connection.getDbDate()).toEqual(expected);
+		expect(await connection.getDbDate({ requestId })).toEqual(expected);
 	});
 
 	test('should return current db server date when there is time drift', async () => {
@@ -854,10 +855,10 @@ describe('getDbDate', () => {
 			mvisAdminPassword,
 			account,
 		);
-		await connection.open();
+		await connection.open({ requestId });
 
 		const expected = '2022-03-08';
-		expect(await connection.getDbDate()).toEqual(expected);
+		expect(await connection.getDbDate({ requestId })).toEqual(expected);
 	});
 });
 
@@ -904,10 +905,10 @@ describe('getDbDateTime', () => {
 			mvisAdminPassword,
 			account,
 		);
-		await connection.open();
+		await connection.open({ requestId });
 
 		const expected = '2022-03-08T12:00:00.000';
-		expect(await connection.getDbDateTime()).toEqual(expected);
+		expect(await connection.getDbDateTime({ requestId })).toEqual(expected);
 	});
 
 	test('should return current db server date and time when there is time drift', async () => {
@@ -940,10 +941,10 @@ describe('getDbDateTime', () => {
 			mvisAdminPassword,
 			account,
 		);
-		await connection.open();
+		await connection.open({ requestId });
 
 		const expected = '2022-03-08T12:00:00.000';
-		expect(await connection.getDbDateTime()).toEqual(expected);
+		expect(await connection.getDbDateTime({ requestId })).toEqual(expected);
 	});
 
 	test('should return calculated db server date and time when using cached server info', async () => {
@@ -976,12 +977,12 @@ describe('getDbDateTime', () => {
 			mvisAdminPassword,
 			account,
 		);
-		await connection.open();
+		await connection.open({ requestId });
 
 		jest.setSystemTime(new Date('2022-03-08T13:00:00.000')); // 1 hour elapsed; still within 6 hour ttl
 
 		const expected = '2022-03-08T13:00:00.000';
-		expect(await connection.getDbDateTime()).toEqual(expected);
+		expect(await connection.getDbDateTime({ requestId })).toEqual(expected);
 		expect(mockedAxiosInstance.post).toHaveBeenCalledTimes(1);
 	});
 
@@ -1025,12 +1026,12 @@ describe('getDbDateTime', () => {
 			mvisAdminPassword,
 			account,
 		);
-		await connection.open();
+		await connection.open({ requestId });
 
 		jest.setSystemTime(new Date('2022-03-08T19:00:00.000')); // 7 hours elapsed; beyond ttl
 
 		const expected = '2022-03-08T19:00:00.000';
-		expect(await connection.getDbDateTime()).toEqual(expected);
+		expect(await connection.getDbDateTime({ requestId })).toEqual(expected);
 		expect(mockedAxiosInstance.post).toHaveBeenCalledTimes(2);
 	});
 
@@ -1074,17 +1075,17 @@ describe('getDbDateTime', () => {
 			mvisAdminPassword,
 			account,
 		);
-		await connection.open();
+		await connection.open({ requestId });
 
 		jest.setSystemTime(new Date('2022-03-08T19:00:00.000')); // 7 hours elapsed; beyond ttl
 
 		const expected = '2022-03-08T19:00:00.000';
-		expect(await connection.getDbDateTime()).toEqual(expected);
+		expect(await connection.getDbDateTime({ requestId })).toEqual(expected);
 
 		const results = await Promise.all([
-			connection.getDbDateTime(),
-			connection.getDbDateTime(),
-			connection.getDbDateTime(),
+			connection.getDbDateTime({ requestId }),
+			connection.getDbDateTime({ requestId }),
+			connection.getDbDateTime({ requestId }),
 		]);
 
 		results.forEach((result) => {
@@ -1138,10 +1139,10 @@ describe('getDbTime', () => {
 			mvisAdminPassword,
 			account,
 		);
-		await connection.open();
+		await connection.open({ requestId });
 
 		const expected = '12:00:00.000';
-		expect(await connection.getDbTime()).toEqual(expected);
+		expect(await connection.getDbTime({ requestId })).toEqual(expected);
 	});
 
 	test('should return current db server time when there is time drift', async () => {
@@ -1174,10 +1175,10 @@ describe('getDbTime', () => {
 			mvisAdminPassword,
 			account,
 		);
-		await connection.open();
+		await connection.open({ requestId });
 
 		const expected = '12:00:00.000';
-		expect(await connection.getDbTime()).toEqual(expected);
+		expect(await connection.getDbTime({ requestId })).toEqual(expected);
 	});
 });
 
@@ -1214,10 +1215,10 @@ describe('getDbLimits', () => {
 			mvisAdminPassword,
 			account,
 		);
-		await connection.open();
+		await connection.open({ requestId });
 
 		const expected = { maxSort: 20, maxWith: 512, maxSentenceLength: 9247 };
-		expect(await connection.getDbLimits()).toEqual(expected);
+		expect(await connection.getDbLimits({ requestId })).toEqual(expected);
 	});
 });
 
@@ -1267,7 +1268,7 @@ describe('model', () => {
 			mvisAdminPassword,
 			account,
 		);
-		await connection.open();
+		await connection.open({ requestId });
 
 		const file = 'file';
 		const Model = connection.model(null, file);

--- a/src/__tests__/Query.test.ts
+++ b/src/__tests__/Query.test.ts
@@ -10,6 +10,7 @@ import type { DataTransformer, DbSubroutineOutputFind } from '../types';
 // eslint-disable-next-line @typescript-eslint/naming-convention
 const ModelConstructorMock = mockDeep<ModelConstructor>();
 const filename = 'filename';
+const requestId = 'requestId';
 // @ts-expect-error: Ignore readonly modifier in test
 ModelConstructorMock.file = filename;
 
@@ -1443,7 +1444,11 @@ describe('exec', () => {
 			const query = new Query(ModelConstructorMock, logHandlerMock, selectionCritieria);
 			const userDefined = { option1: 'foo', option2: 'bar', option3: 'baz' };
 			const maxReturnPayloadSize = 10_000;
-			const executionOptions: QueryExecutionOptions = { userDefined, maxReturnPayloadSize };
+			const executionOptions: QueryExecutionOptions = {
+				userDefined,
+				maxReturnPayloadSize,
+				requestId,
+			};
 			expect(await query.exec(executionOptions)).toEqual(dbQueryResult);
 
 			const expectedQuery = `select ${filename} with ${propertyDictionary} = "${propertyValue}"`;
@@ -1454,7 +1459,7 @@ describe('exec', () => {
 					projection: null,
 					queryCommand: expectedQuery,
 				},
-				{ maxReturnPayloadSize, userDefined },
+				{ maxReturnPayloadSize, requestId, userDefined },
 			);
 		});
 	});

--- a/src/__tests__/compileModel.test.ts
+++ b/src/__tests__/compileModel.test.ts
@@ -29,6 +29,7 @@ const schemaDefinition: SchemaDefinition = {
 };
 const schema = new Schema(schemaDefinition);
 const filename = 'test.file';
+const requestId = 'requestId';
 
 const { am, vm, svm } = mockDelimiters;
 
@@ -115,12 +116,12 @@ describe('deleteById', () => {
 
 		const userDefined = { option1: 'foo', option2: 'bar', option3: 'baz' };
 		const maxReturnPayloadSize = 10_000;
-		const options: ModelDeleteByIdOptions = { userDefined, maxReturnPayloadSize };
+		const options: ModelDeleteByIdOptions = { userDefined, maxReturnPayloadSize, requestId };
 		expect(await Model.deleteById(id, options)).toBeNull();
 		expect(connectionMock.executeDbSubroutine).toHaveBeenCalledWith(
 			'deleteById',
 			{ filename, id },
-			{ userDefined, maxReturnPayloadSize },
+			{ userDefined, maxReturnPayloadSize, requestId },
 		);
 	});
 });
@@ -187,7 +188,7 @@ describe('find', () => {
 
 		const userDefined = { option1: 'foo', option2: 'bar', option3: 'baz' };
 		const maxReturnPayloadSize = 10_000;
-		const options: ModelFindOptions = { maxReturnPayloadSize, userDefined };
+		const options: ModelFindOptions = { maxReturnPayloadSize, userDefined, requestId };
 
 		const documents = await Model.find({}, options);
 		documents.forEach((document) => {
@@ -206,7 +207,7 @@ describe('find', () => {
 				projection: null,
 				queryCommand: `select ${filename}`,
 			},
-			{ maxReturnPayloadSize, userDefined },
+			{ maxReturnPayloadSize, userDefined, requestId },
 		);
 	});
 });
@@ -274,7 +275,7 @@ describe('findAndCount', () => {
 
 		const userDefined = { option1: 'foo', option2: 'bar', option3: 'baz' };
 		const maxReturnPayloadSize = 10_000;
-		const options: ModelFindOptions = { maxReturnPayloadSize, userDefined };
+		const options: ModelFindOptions = { maxReturnPayloadSize, userDefined, requestId };
 
 		const { count, documents } = await Model.findAndCount({}, options);
 		expect(count).toBe(2);
@@ -294,7 +295,7 @@ describe('findAndCount', () => {
 				projection: null,
 				queryCommand: `select ${filename}`,
 			},
-			{ maxReturnPayloadSize, userDefined },
+			{ maxReturnPayloadSize, userDefined, requestId },
 		);
 	});
 });
@@ -382,7 +383,7 @@ describe('findById', () => {
 
 		const userDefined = { option1: 'foo', option2: 'bar', option3: 'baz' };
 		const maxReturnPayloadSize = 10_000;
-		const options: ModelFindByIdOptions = { maxReturnPayloadSize, userDefined };
+		const options: ModelFindByIdOptions = { maxReturnPayloadSize, userDefined, requestId };
 
 		const document = await Model.findById(id1, options);
 
@@ -396,7 +397,7 @@ describe('findById', () => {
 				id: id1,
 				projection: null,
 			},
-			{ maxReturnPayloadSize, userDefined },
+			{ maxReturnPayloadSize, userDefined, requestId },
 		);
 	});
 
@@ -540,7 +541,7 @@ describe('findByIds', () => {
 
 		const userDefined = { option1: 'foo', option2: 'bar', option3: 'baz' };
 		const maxReturnPayloadSize = 10_000;
-		const options: ModelFindByIdOptions = { maxReturnPayloadSize, userDefined };
+		const options: ModelFindByIdOptions = { maxReturnPayloadSize, userDefined, requestId };
 
 		const documents = await Model.findByIds([id1, id2], options);
 		documents.forEach((document) => {
@@ -559,7 +560,7 @@ describe('findByIds', () => {
 				ids: [id1, id2],
 				projection: null,
 			},
-			{ maxReturnPayloadSize, userDefined },
+			{ maxReturnPayloadSize, userDefined, requestId },
 		);
 	});
 
@@ -629,7 +630,11 @@ describe('readFileContentsById', () => {
 
 		const userDefined = { option1: 'foo', option2: 'bar', option3: 'baz' };
 		const maxReturnPayloadSize = 10_000;
-		const options: ModelReadFileContentsByIdOptions = { maxReturnPayloadSize, userDefined };
+		const options: ModelReadFileContentsByIdOptions = {
+			maxReturnPayloadSize,
+			userDefined,
+			requestId,
+		};
 
 		const contents = await Model.readFileContentsById(id1, options);
 		expect(contents).toBe(mockResult);
@@ -639,7 +644,7 @@ describe('readFileContentsById', () => {
 				filename,
 				id: id1,
 			},
-			{ maxReturnPayloadSize, userDefined },
+			{ maxReturnPayloadSize, userDefined, requestId },
 		);
 	});
 });
@@ -912,7 +917,7 @@ describe('save', () => {
 
 			const userDefined = { option1: 'foo', option2: 'bar', option3: 'baz' };
 			const maxReturnPayloadSize = 10_000;
-			const options: ModelSaveOptions = { maxReturnPayloadSize, userDefined };
+			const options: ModelSaveOptions = { maxReturnPayloadSize, userDefined, requestId };
 
 			const result = await model.save(options);
 
@@ -932,7 +937,7 @@ describe('save', () => {
 						{ entityIds: ['prop1-value'], entityName: 'prop1', filename: 'FK_FILE' },
 					],
 				},
-				{ maxReturnPayloadSize, userDefined },
+				{ maxReturnPayloadSize, userDefined, requestId },
 			);
 		});
 	});

--- a/src/compileModel.ts
+++ b/src/compileModel.ts
@@ -28,6 +28,7 @@ export interface ModelFindAndCountResult {
 
 export interface ModelDatabaseExecutionOptions {
 	userDefined?: DbSubroutineUserDefinedOptions;
+	requestId?: string;
 	/** Maximum allowed return payload size in bytes */
 	maxReturnPayloadSize?: number;
 }
@@ -128,7 +129,7 @@ const compileModel = <TSchema extends GenericObject = GenericObject>(
 			id: string,
 			options: ModelDeleteByIdOptions = {},
 		): Promise<Model | null> {
-			const { maxReturnPayloadSize, userDefined } = options;
+			const { maxReturnPayloadSize, requestId, userDefined } = options;
 
 			const data = await this.connection.executeDbSubroutine(
 				'deleteById',
@@ -138,6 +139,7 @@ const compileModel = <TSchema extends GenericObject = GenericObject>(
 				},
 				{
 					...(maxReturnPayloadSize && { maxReturnPayloadSize }),
+					...(requestId && { requestId }),
 					...(userDefined && { userDefined }),
 				},
 			);
@@ -156,10 +158,11 @@ const compileModel = <TSchema extends GenericObject = GenericObject>(
 			selectionCriteria: Filter<TSchema> = {},
 			options: ModelFindOptions = {},
 		): Promise<Model[]> {
-			const { maxReturnPayloadSize, userDefined, ...queryConstructorOptions } = options;
+			const { maxReturnPayloadSize, requestId, userDefined, ...queryConstructorOptions } = options;
 			const query = new Query(Model, Model.#logHandler, selectionCriteria, queryConstructorOptions);
 			const { documents } = await query.exec({
 				...(maxReturnPayloadSize && { maxReturnPayloadSize }),
+				...(requestId && { requestId }),
 				...(userDefined && { userDefined }),
 			});
 
@@ -174,10 +177,11 @@ const compileModel = <TSchema extends GenericObject = GenericObject>(
 			selectionCriteria: Filter<TSchema> = {},
 			options: ModelFindOptions = {},
 		): Promise<ModelFindAndCountResult> {
-			const { maxReturnPayloadSize, userDefined, ...queryConstructorOptions } = options;
+			const { maxReturnPayloadSize, requestId, userDefined, ...queryConstructorOptions } = options;
 			const query = new Query(Model, Model.#logHandler, selectionCriteria, queryConstructorOptions);
 			const { count, documents } = await query.exec({
 				...(maxReturnPayloadSize && { maxReturnPayloadSize }),
+				...(requestId && { requestId }),
 				...(userDefined && { userDefined }),
 			});
 
@@ -197,7 +201,7 @@ const compileModel = <TSchema extends GenericObject = GenericObject>(
 			id: string,
 			options: ModelFindByIdOptions = {},
 		): Promise<Model | null> {
-			const { maxReturnPayloadSize, projection, userDefined } = options;
+			const { maxReturnPayloadSize, requestId, projection, userDefined } = options;
 
 			const data = await this.connection.executeDbSubroutine(
 				'findById',
@@ -208,6 +212,7 @@ const compileModel = <TSchema extends GenericObject = GenericObject>(
 				},
 				{
 					...(maxReturnPayloadSize && { maxReturnPayloadSize }),
+					...(requestId && { requestId }),
 					...(userDefined && { userDefined }),
 				},
 			);
@@ -226,7 +231,7 @@ const compileModel = <TSchema extends GenericObject = GenericObject>(
 			ids: string | string[],
 			options: ModelFindByIdOptions = {},
 		): Promise<(Model | null)[]> {
-			const { maxReturnPayloadSize, projection, userDefined } = options;
+			const { maxReturnPayloadSize, requestId, projection, userDefined } = options;
 
 			const idsArray = ensureArray(ids);
 			const data = await this.connection.executeDbSubroutine(
@@ -238,6 +243,7 @@ const compileModel = <TSchema extends GenericObject = GenericObject>(
 				},
 				{
 					...(maxReturnPayloadSize && { maxReturnPayloadSize }),
+					...(requestId && { requestId }),
 					...(userDefined && { userDefined }),
 				},
 			);
@@ -257,7 +263,7 @@ const compileModel = <TSchema extends GenericObject = GenericObject>(
 			id: string,
 			options: ModelReadFileContentsByIdOptions = {},
 		): Promise<string> {
-			const { maxReturnPayloadSize, userDefined } = options;
+			const { maxReturnPayloadSize, requestId, userDefined } = options;
 			const data = await this.connection.executeDbSubroutine(
 				'readFileContentsById',
 				{
@@ -266,6 +272,7 @@ const compileModel = <TSchema extends GenericObject = GenericObject>(
 				},
 				{
 					...(maxReturnPayloadSize && { maxReturnPayloadSize }),
+					...(requestId && { requestId }),
 					...(userDefined && { userDefined }),
 				},
 			);
@@ -291,7 +298,7 @@ const compileModel = <TSchema extends GenericObject = GenericObject>(
 
 		/** Save a document to the database */
 		public async save(options: ModelSaveOptions = {}): Promise<Model> {
-			const { maxReturnPayloadSize, userDefined } = options;
+			const { maxReturnPayloadSize, requestId, userDefined } = options;
 			if (this._id == null) {
 				throw new TypeError('_id value must be set prior to saving');
 			}
@@ -318,6 +325,7 @@ const compileModel = <TSchema extends GenericObject = GenericObject>(
 					},
 					{
 						...(maxReturnPayloadSize && { maxReturnPayloadSize }),
+						...(requestId && { requestId }),
 						...(userDefined && { userDefined }),
 					},
 				);

--- a/src/types/DbSubroutineInput.ts
+++ b/src/types/DbSubroutineInput.ts
@@ -11,6 +11,7 @@ export interface DbSubroutineUserDefinedOptions {
 
 export interface DbSubroutineSetupOptions {
 	userDefined?: DbSubroutineUserDefinedOptions;
+	/** Trace ID passed as a request header. Defined here for future use by the database server logic */
 	requestId?: string;
 	/** Maximum allowed return payload size in bytes */
 	maxReturnPayloadSize?: number;

--- a/src/types/DbSubroutineInput.ts
+++ b/src/types/DbSubroutineInput.ts
@@ -11,6 +11,7 @@ export interface DbSubroutineUserDefinedOptions {
 
 export interface DbSubroutineSetupOptions {
 	userDefined?: DbSubroutineUserDefinedOptions;
+	requestId?: string;
 	/** Maximum allowed return payload size in bytes */
 	maxReturnPayloadSize?: number;
 }


### PR DESCRIPTION
This PR adds functionality to pass a request/trace ID through MVOM requests. MVIS 1.3.2 allows a request ID to be specified using the request header `X-MVIS-Trace-Id`. If a request ID is not specified, a random UUID will be generated to be used.

While testing I noticed that MVIS may create separate ROOT actions from a request and will generate a separate X-MVIS-Trace-Id value for those actions. I will update Rocket case 00884089 to ask about these ID values. An example below:

Request ID created by the services for `item.query`: 9619d006-2f05-4b4e-bd25-01d7506242b1

```
[X-MVIS-Trace-Id:SELF: 9619d006-2f05-4b4e-bd25-01d7506242b1] 2023-03-01 16:55:32:850 [qtp1620890840-21035] INFO  com.rs.u2.u2rest.b.c - HTTP request IP address: 10.1.1.201
[X-MVIS-Trace-Id:SELF: 9619d006-2f05-4b4e-bd25-01d7506242b1] 2023-03-01 16:55:32:850 [qtp1620890840-21035] INFO  com.rs.u2.u2rest.b.c - HTTP request user: (anonymous)
[X-MVIS-Trace-Id:SELF: 9619d006-2f05-4b4e-bd25-01d7506242b1] 2023-03-01 16:55:32:887 [qtp1620890840-21035] INFO  com.rs.u2.u2rest.b.c - [dev-107] The tracer data sent to dataserver: 'REST=1'
[X-MVIS-Trace-Id:ROOT: 1367a7ad-0fc2-4b9d-89c8-973d4a50f3f6] 2023-03-01 16:55:33:451 [qtp1620890840-22069] INFO  com.rs.u2.u2rest.b.c - HTTP request IP address: 10.1.2.146
[X-MVIS-Trace-Id:ROOT: 71f426a4-884d-432c-8281-5aec593e6c45] 2023-03-01 16:55:33:451 [qtp1620890840-22068] INFO  com.rs.u2.u2rest.b.c - HTTP request IP address: 10.1.2.146
[X-MVIS-Trace-Id:ROOT: 71f426a4-884d-432c-8281-5aec593e6c45] 2023-03-01 16:55:33:451 [qtp1620890840-22068] INFO  com.rs.u2.u2rest.b.c - HTTP request user: (anonymous)
[X-MVIS-Trace-Id:ROOT: 1367a7ad-0fc2-4b9d-89c8-973d4a50f3f6] 2023-03-01 16:55:33:451 [qtp1620890840-22069] INFO  com.rs.u2.u2rest.b.c - HTTP request user: (anonymous)
````