### PR TITLE
Lower coverage thesholds. Remove istanbull ignores

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,7 +70,7 @@ Ensures that code performs as expected under test scenarios.
 
 #### test:coverage
 
-Monitors coverage of the tests. There is a strict policy of enforcing 100% code coverage. If something is not readily testable, the specific area can be ignored with an `istanbul ignore` comment, but an explanation of the rationale for ignoring should be included in the comment.
+Monitors coverage of the tests. The coverage threshold is 25% for each individual file.
 
 #### typecheck
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -17,11 +17,11 @@ module.exports = {
 		'!**/scripts/**', // do not test scripts
 	],
 	coverageThreshold: {
-		global: {
-			branches: 100,
-			functions: 100,
-			lines: 100,
-			statements: 100,
+		'**/*.?([cm])[jt]s?(x)': {
+			statements: 25,
+			branches: 25,
+			functions: 25,
+			lines: 25,
 		},
 	},
 };

--- a/src/Connection.ts
+++ b/src/Connection.ts
@@ -320,28 +320,24 @@ class Connection {
 	}
 
 	/** Get the current ISOCalendarDate from the database */
-	/* istanbul ignore next: Optional parameter is covered by executeDbSubroutine test "should generate requestID if not provided" */
 	public async getDbDate({ requestId }: GetDbDateOptions = {}): Promise<string> {
 		const { timeDrift } = await this.getDbServerInfo({ requestId });
 		return format(addMilliseconds(Date.now(), timeDrift), ISOCalendarDateFormat);
 	}
 
 	/** Get the current ISOCalendarDateTime from the database */
-	/* istanbul ignore next: Optional parameter is covered by executeDbSubroutine test "should generate requestID if not provided" */
 	public async getDbDateTime({ requestId }: GetDbDateTimeOptions = {}): Promise<string> {
 		const { timeDrift } = await this.getDbServerInfo({ requestId });
 		return format(addMilliseconds(Date.now(), timeDrift), ISOCalendarDateTimeFormat);
 	}
 
 	/** Get the current ISOTime from the database */
-	/* istanbul ignore next: Optional parameter is covered by executeDbSubroutine test "should generate requestID if not provided" */
 	public async getDbTime({ requestId }: GetDbTimeOptions = {}): Promise<string> {
 		const { timeDrift } = await this.getDbServerInfo({ requestId });
 		return format(addMilliseconds(Date.now(), timeDrift), ISOTimeFormat);
 	}
 
 	/** Get the multivalue database server limits */
-	/* istanbul ignore next: Optional parameter is covered by executeDbSubroutine test "should generate requestID if not provided" */
 	public async getDbLimits({ requestId }: GetDbLimitsOptions = {}): Promise<DbServerLimits> {
 		const { limits } = await this.getDbServerInfo({ requestId });
 		return limits;
@@ -363,7 +359,6 @@ class Connection {
 	}
 
 	/** Get the db server information (date, time, etc.) */
-	/* istanbul ignore next: Optional parameter is covered by executeDbSubroutine test "should generate requestID if not provided" */
 	private async getDbServerInfo({ requestId }: DbServerInfoOptions = {}): Promise<ServerInfo> {
 		// set a mutex on acquiring server information so multiple simultaneous requests are not modifying the cache
 		return this.serverInfoMutex.runExclusive(async () => {

--- a/src/Query.ts
+++ b/src/Query.ts
@@ -331,7 +331,6 @@ class Query<TSchema extends GenericObject = GenericObject> {
 	/** Transform query constant to internal u2 format (if applicable) */
 	private transformToQuery(property: string, constant: unknown): unknown {
 		const dictionaryTypeDetail = this.Model.schema?.dictPaths.get(property);
-		/* istanbul ignore if: Would have thrown previously in getDictionaryId */
 		if (dictionaryTypeDetail == null) {
 			throw new InvalidParameterError({
 				message: 'Nonexistent schema property or property does not have a dictionary specified',

--- a/src/Schema.ts
+++ b/src/Schema.ts
@@ -225,7 +225,6 @@ class Schema {
 						dictionary,
 						dataTransformer: new ISOTimeDataTransformer(dictionaryDefinition.dbFormat),
 					});
-				/* istanbul ignore next: cannot hit without violating types */
 				default:
 					return acc;
 			}
@@ -356,7 +355,6 @@ class Schema {
 			case 'string':
 				schemaTypeValue = new StringType(castee, options);
 				break;
-			/* istanbul ignore next: the block below is for checking not implemented case for any new scalar value */
 			default: {
 				const exhaustiveCheck: never = castee;
 				throw new InvalidParameterError({


### PR DESCRIPTION
This PR lowers the coverage threshold to 25% for each individual file vs 100% globally. It also removes all `istanbull ignore` comments as they are no longer needed.