### PR TITLE
Add requestId to common variable

### DIFF
--- a/src/Connection.ts
+++ b/src/Connection.ts
@@ -289,7 +289,7 @@ class Connection {
 			);
 		}
 
-		const updatedSetupOptions = { ...setupOptions, maxReturnPayloadSize };
+		const updatedSetupOptions = { ...setupOptions, maxReturnPayloadSize, requestId };
 
 		this.logHandler.debug(`executing database subroutine "${subroutineName}"`);
 

--- a/src/__tests__/Connection.test.ts
+++ b/src/__tests__/Connection.test.ts
@@ -392,7 +392,7 @@ describe('executeDbSubroutine', () => {
 		).rejects.toThrow();
 	});
 
-	test('should generate requestID if not provided', async () => {
+	test('should generate requestID if not provided and provide it as a setup option', async () => {
 		(crypto.randomUUID as jest.Mock).mockReturnValue('randomUuid');
 
 		when<any, any[]>(mockedAxiosInstance.post)
@@ -437,6 +437,7 @@ describe('executeDbSubroutine', () => {
 					subroutineInput: {},
 					setupOptions: {
 						maxReturnPayloadSize: 100_000_000,
+						requestId: expect.stringContaining('randomUuid'),
 					},
 					teardownOptions: {},
 				},

--- a/src/unibasicTemplates/common/mvom.njk
+++ b/src/unibasicTemplates/common/mvom.njk
@@ -1,0 +1,8 @@
+$ifndef mvom.com
+$define mvom.com
+
+com /S$MVOM/ S$MVOM.PROCESS
+com /S$MVOM/ S$MVOM.USER1, S$MVOM.USER2, S$MVOM.USER3, S$MVOM.USER4, S$MVOM.USER5
+com /S$MVOM/ S$MVOM.REQUEST.ID
+
+$endif

--- a/src/unibasicTemplates/main.njk
+++ b/src/unibasicTemplates/main.njk
@@ -50,6 +50,7 @@ if udoGetProperty(input, 'teardownOptions', teardownOptions, type) then
   go response
 end
 
+parsedSetupOptions = ''
 call mvom_setup(setupOptions, parsedSetupOptions)
 
 subroutineName = 'mvom_':subroutineId

--- a/src/unibasicTemplates/subroutines/internal/setup.njk
+++ b/src/unibasicTemplates/subroutines/internal/setup.njk
@@ -1,13 +1,17 @@
 subroutine mvom_setup(setupOptions, parsedSetupOptions)
+{% include "../../common/mvom.njk" %}
 {% include "../../constants/setup.njk" %}
 
 * Perform any needed environment setup
 
-com /S$MVOM/ S$MVOM.PROCESS
-com /S$MVOM/ S$MVOM.USER1, S$MVOM.USER2, S$MVOM.USER3, S$MVOM.USER4, S$MVOM.USER5
 S$MVOM.PROCESS = @TRUE
 
 gosub processUserDefinedOptions
+
+S$MVOM.REQUEST.ID = ''
+if udoGetProperty(setupOptions, 'requestId', requestId, type) eq 0 then
+  S$MVOM.REQUEST.ID = requestId
+end
 
 if udoGetProperty(setupOptions, 'maxReturnPayloadSize', maxReturnPayloadSize, type) then
   * Value not provided. Default to 100MB


### PR DESCRIPTION
This PR updates the server-side setup routine to set the `requestId` to a new common variable in our `S$MVOM` common block called `S$MVOM.REQUEST.ID`.

With this change any UniBasic trigger programs that define our common block can utilize the request id for their logging.

I also fixed an uninitialized variable warning in the mvom main program that I introduced when I added support for a max return payload size.