### PR TITLE
bump minimum node version to 16.0.0

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -3,7 +3,7 @@ module.exports = {
 	env: {
 		build: {
 			ignore: ['**/*.test.ts', '**/__mocks__/**'],
-			presets: [['@babel/env', { targets: { node: '16.19.1' } }], '@babel/typescript'],
+			presets: [['@babel/env', { targets: { node: '16.0.0' } }], '@babel/typescript'],
 		},
 		debug: { sourceMaps: 'inline', retainLines: true },
 	},

--- a/.babelrc.js
+++ b/.babelrc.js
@@ -3,7 +3,7 @@ module.exports = {
 	env: {
 		build: {
 			ignore: ['**/*.test.ts', '**/__mocks__/**'],
-			presets: [['@babel/env', { targets: { node: '14.19.0' } }], '@babel/typescript'],
+			presets: [['@babel/env', { targets: { node: '16.19.1' } }], '@babel/typescript'],
 		},
 		debug: { sourceMaps: 'inline', retainLines: true },
 	},

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,7 @@ jobs:
     needs: setup
     strategy:
       matrix:
-        node: ['14', '16', '18']
+        node: ['16', '18']
 
     steps:
       - uses: actions/checkout@v3

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
         "typescript": "4.9.5"
       },
       "engines": {
-        "node": ">=16.19"
+        "node": ">=16"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
         "typescript": "4.9.5"
       },
       "engines": {
-        "node": ">=14.19"
+        "node": ">=16.19"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Multivalue Object Mapper",
   "main": "index.js",
   "engines": {
-    "node": ">=16.19"
+    "node": ">=16"
   },
   "scripts": {
     "build": "npm-run-all build:node build:unibasic build:copy-files build:declaration",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Multivalue Object Mapper",
   "main": "index.js",
   "engines": {
-    "node": ">=14.19"
+    "node": ">=16.19"
   },
   "scripts": {
     "build": "npm-run-all build:node build:unibasic build:copy-files build:declaration",


### PR DESCRIPTION
This PR removes support for node version 14, which will be out of support at the end of April. The new minimum version is 16.0.0.