### PR TITLE
Standardize logging levels

### DIFF
--- a/src/LogHandler.ts
+++ b/src/LogHandler.ts
@@ -3,16 +3,16 @@ interface LogFunction {
 }
 
 export interface Logger {
+	fatal: LogFunction;
 	error: LogFunction;
 	warn: LogFunction;
 	info: LogFunction;
-	verbose: LogFunction;
 	debug: LogFunction;
-	silly: LogFunction;
+	trace: LogFunction;
 }
 
 /** Handle logging */
-class LogHandler {
+class LogHandler implements Logger {
 	private account: string;
 
 	private logger?: Logger;
@@ -20,6 +20,11 @@ class LogHandler {
 	public constructor(account: string, logger?: Logger) {
 		this.account = account;
 		this.logger = logger;
+	}
+
+	/** Emit a fatal level log */
+	public fatal(message: string): void {
+		return this.log('fatal', message);
 	}
 
 	/** Emit an error level log */
@@ -37,19 +42,14 @@ class LogHandler {
 		return this.log('info', message);
 	}
 
-	/** Emit a verbose level log */
-	public verbose(message: string): void {
-		return this.log('verbose', message);
-	}
-
 	/** Emit a debug level log */
 	public debug(message: string): void {
 		return this.log('debug', message);
 	}
 
-	/** Emit a silly level log */
-	public silly(message: string): void {
-		return this.log('silly', message);
+	/** Emit a trace level log */
+	public trace(message: string): void {
+		return this.log('trace', message);
 	}
 
 	/** Log a message to logger */

--- a/src/Query.ts
+++ b/src/Query.ts
@@ -149,7 +149,7 @@ class Query<TSchema extends GenericObject = GenericObject> {
 			...(userDefined && { userDefined }),
 		};
 
-		this.logHandler.verbose(`executing query "${queryCommand}"`);
+		this.logHandler.debug(`executing query "${queryCommand}"`);
 		const data = await this.Model.connection.executeDbSubroutine(
 			'find',
 			executionOptions,

--- a/src/__tests__/Connection.test.ts
+++ b/src/__tests__/Connection.test.ts
@@ -158,8 +158,8 @@ describe('createConnection', () => {
 
 		const message = 'test message';
 		// @ts-expect-error: accessing private member in test
-		connection.logHandler.silly(message);
-		expect(loggerMock.silly).toHaveBeenCalledWith(`[${account}] ${message}`);
+		connection.logHandler.trace(message);
+		expect(loggerMock.trace).toHaveBeenCalledWith(`[${account}] ${message}`);
 	});
 
 	test('should allow for override of timeout', () => {

--- a/src/__tests__/LogHandler.test.ts
+++ b/src/__tests__/LogHandler.test.ts
@@ -1,16 +1,33 @@
 import LogHandler from '../LogHandler';
 
 const loggerMock = {
+	fatal: jest.fn(),
 	error: jest.fn(),
 	warn: jest.fn(),
 	info: jest.fn(),
-	verbose: jest.fn(),
 	debug: jest.fn(),
-	silly: jest.fn(),
+	trace: jest.fn(),
 };
 
 const account = 'accountName';
 const message = 'test message';
+
+describe('fatal', () => {
+	test('should not emit log if no logger specified', () => {
+		const logHandler = new LogHandler(account);
+		logHandler.fatal(message);
+
+		expect(loggerMock.fatal).not.toHaveBeenCalled();
+	});
+
+	test('should emit log at fatal level', () => {
+		const logHandler = new LogHandler(account, loggerMock);
+		logHandler.fatal(message);
+
+		const expected = `[${account}] ${message}`;
+		expect(loggerMock.fatal).toHaveBeenCalledWith(expected);
+	});
+});
 
 describe('error', () => {
 	test('should not emit log if no logger specified', () => {
@@ -63,23 +80,6 @@ describe('info', () => {
 	});
 });
 
-describe('verbose', () => {
-	test('should not emit log if no logger specified', () => {
-		const logHandler = new LogHandler(account);
-		logHandler.verbose(message);
-
-		expect(loggerMock.verbose).not.toHaveBeenCalled();
-	});
-
-	test('should emit log at verbose level', () => {
-		const logHandler = new LogHandler(account, loggerMock);
-		logHandler.verbose(message);
-
-		const expected = `[${account}] ${message}`;
-		expect(loggerMock.verbose).toHaveBeenCalledWith(expected);
-	});
-});
-
 describe('debug', () => {
 	test('should not emit log if no logger specified', () => {
 		const logHandler = new LogHandler(account);
@@ -97,19 +97,19 @@ describe('debug', () => {
 	});
 });
 
-describe('silly', () => {
+describe('trace', () => {
 	test('should not emit log if no logger specified', () => {
 		const logHandler = new LogHandler(account);
-		logHandler.silly(message);
+		logHandler.trace(message);
 
-		expect(loggerMock.silly).not.toHaveBeenCalled();
+		expect(loggerMock.trace).not.toHaveBeenCalled();
 	});
 
-	test('should emit log at silly level', () => {
+	test('should emit log at trace level', () => {
 		const logHandler = new LogHandler(account, loggerMock);
-		logHandler.silly(message);
+		logHandler.trace(message);
 
 		const expected = `[${account}] ${message}`;
-		expect(loggerMock.silly).toHaveBeenCalledWith(expected);
+		expect(loggerMock.trace).toHaveBeenCalledWith(expected);
 	});
 });


### PR DESCRIPTION
This PR adjusts the logging levels being used by the library, removing `verbose` and `silly` and adding `fatal` and `trace`.