### PR TITLE
Remove use of @storis/prettier-config and internalize configuration

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,17 @@
+{
+  "printWidth": 100,
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "bracketSpacing": true,
+  "bracketSameLine": false,
+  "arrowParens": "always",
+  "overrides": [
+    {
+      "files": ["*.{cjs,mjs,js,jsx,ts,tsx,d.ts,css,html,graphql}"],
+      "options": { "useTabs": true }
+    }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,6 @@
         "@babel/preset-env": "7.21.5",
         "@babel/preset-typescript": "7.21.5",
         "@storis/eslint-config": "4.0.0",
-        "@storis/prettier-config": "1.0.0",
         "@storis/tsconfig": "1.0.0",
         "@types/fs-extra": "11.0.1",
         "@types/jest-when": "3.5.2",
@@ -3055,18 +3054,6 @@
         "eslint-plugin-testing-library": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@storis/prettier-config": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@storis/prettier-config/-/prettier-config-1.0.0.tgz",
-      "integrity": "sha512-/FZXJqbNeTQ/yqbJKbC91rYH88nYfGZpc9MjtK4MYo3kFXiHyeT5lXAzvHiVZjM9Xr+nsdf5VmMhFMXkn70Bgg==",
-      "dev": true,
-      "engines": {
-        "node": "^16.0.0 || ^18.0.0"
-      },
-      "peerDependencies": {
-        "prettier": ">=2.5.0"
       }
     },
     "node_modules/@storis/tsconfig": {
@@ -12751,13 +12738,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@storis/eslint-config/-/eslint-config-4.0.0.tgz",
       "integrity": "sha512-xOybKTecx1tByTuad9mkb+NF6BDtRrS6Ii3zYN2N50R812LQzKLO5//sYhkGx1J5HK+vvrvrmWggL0i05Yx+TA==",
-      "dev": true,
-      "requires": {}
-    },
-    "@storis/prettier-config": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@storis/prettier-config/-/prettier-config-1.0.0.tgz",
-      "integrity": "sha512-/FZXJqbNeTQ/yqbJKbC91rYH88nYfGZpc9MjtK4MYo3kFXiHyeT5lXAzvHiVZjM9Xr+nsdf5VmMhFMXkn70Bgg==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "@babel/preset-env": "7.21.5",
     "@babel/preset-typescript": "7.21.5",
     "@storis/eslint-config": "4.0.0",
-    "@storis/prettier-config": "1.0.0",
     "@storis/tsconfig": "1.0.0",
     "@types/fs-extra": "11.0.1",
     "@types/jest-when": "3.5.2",
@@ -85,6 +84,5 @@
     "rimraf": "5.0.0",
     "typescript": "4.9.5"
   },
-  "types": "index.d.ts",
-  "prettier": "@storis/prettier-config"
+  "types": "index.d.ts"
 }

--- a/scripts/copy-files.ts
+++ b/scripts/copy-files.ts
@@ -9,7 +9,7 @@ const buildPath = path.resolve(process.cwd(), './dist');
 const createPackageFile = async (): Promise<void> => {
 	const source = path.resolve(process.cwd(), './package.json');
 	const packageFile = await fse.readFile(source, 'utf8');
-	const { scripts, devDependencies, prettier, ...packageDataOther } = JSON.parse(packageFile);
+	const { scripts, devDependencies, ...packageDataOther } = JSON.parse(packageFile);
 
 	const newPackageData = {
 		...packageDataOther,


### PR DESCRIPTION
This PR removes the use of `@storis/prettier-config` to set the configuration for prettier as that package is no longer being maintained.  A `.prettierrc.json` file has been added to internalize the settings for prettier.