### PR TITLE
Remove the onlyNpm preset from renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,6 @@
 {
   "extends": [
     "config:base",
-    ":onlyNpm",
     ":automergeTypes",
     ":automergeMinor",
     ":rebaseStalePrs",


### PR DESCRIPTION
The `:onlyNpm` preset was removed from renovate in renovatebot/renovate#25644. This PR eliminates the use of the preset.

Fixes #619.