### PR TITLE
Fix Projection

### DIFF
--- a/src/__tests__/compileModel.test.ts
+++ b/src/__tests__/compileModel.test.ts
@@ -210,6 +210,42 @@ describe('find', () => {
 			{ maxReturnPayloadSize, userDefined, requestId },
 		);
 	});
+
+	test('projection test', async () => {
+		const Model = compileModel(connectionMock, schema, filename, mockDelimiters, logHandlerMock);
+
+		const id1 = 'id1';
+		const version1 = '1';
+		const id2 = 'id2';
+		const version2 = '2';
+		connectionMock.executeDbSubroutine.mockResolvedValue({
+			count: 1,
+			documents: [{ _id: id1, __v: version1, record: `foo${am}20` }],
+		});
+
+		const userDefined = { option1: 'foo', option2: 'bar', option3: 'baz' };
+		const maxReturnPayloadSize = 10_000;
+		const projection = ['prop2'];
+		const options: ModelFindOptions = { maxReturnPayloadSize, userDefined, requestId, projection };
+
+		const documents = await Model.find({}, options);
+		documents.forEach((document) => {
+			expect(document).toBeInstanceOf(Model);
+		});
+
+		const [document1] = documents;
+		expect(document1._id).toBe(id1);
+		expect(document1.__v).toBe(version1);
+		expect(connectionMock.executeDbSubroutine).toHaveBeenCalledWith(
+			'find',
+			{
+				filename,
+				projection: ['prop2'],
+				queryCommand: `select ${filename}`,
+			},
+			{ maxReturnPayloadSize, userDefined, requestId },
+		);
+	});
 });
 
 describe('findAndCount', () => {

--- a/src/compileModel.ts
+++ b/src/compileModel.ts
@@ -165,10 +165,12 @@ const compileModel = <TSchema extends GenericObject = GenericObject>(
 				...(userDefined && { userDefined }),
 			});
 
-			return documents.map((document) => {
+			const result = documents.map((document) => {
 				const { _id, __v, record } = document;
 				return this.#createModelFromRecordString(record, _id, __v);
 			});
+
+			return result;
 		}
 
 		/** Find documents via query, returning them along with a count */

--- a/src/unibasicTemplates/subroutines/internal/formatDocument.njk
+++ b/src/unibasicTemplates/subroutines/internal/formatDocument.njk
@@ -74,7 +74,8 @@ if useProjection then
   recordContents = ''
   lastProjectionPosition = dcount(projectionPositions, @am)
   for position = 1 to lastProjectionPosition
-    recordContents<position> = record<position>
+    projectionPosition = projectionPositions<position>
+    recordContents<projectionPosition> = record<projectionPosition>
   next position
 end else
   recordContents = record


### PR DESCRIPTION
This PR fixes the format_document u2 subroutine's handling of the `projection` option.
Before this fix, when formatting the output document it was not using the passed in `projection`. It was using the loop index. This PR ensures the provided projection positions get used when formatting the output document.