### PR TITLE
Make validators synchronous to improve performance

### DIFF
--- a/src/__tests__/Document.test.ts
+++ b/src/__tests__/Document.test.ts
@@ -789,11 +789,11 @@ describe('buildForeignKeyDefinitions', () => {
 });
 
 describe('validate', () => {
-	test('should return no errors if schema is null', async () => {
+	test('should return no errors if schema is null', () => {
 		const document = new DocumentSubclass(null, { record: [] });
 
 		const expected = new Map();
-		expect(await document.validate()).toEqual(expected);
+		expect(document.validate()).toEqual(expected);
 	});
 
 	describe('id matching validation', () => {
@@ -804,23 +804,23 @@ describe('validate', () => {
 			idMatch: /^foo$/,
 		});
 
-		test('should return error if id match is specified and id does not match pattern', async () => {
+		test('should return error if id match is specified and id does not match pattern', () => {
 			const document = new DocumentSubclass(schema, { data: { _id: 'id', prop1: 'foo' } });
 
 			const expected = new Map([['_id', ['Document id does not match pattern']]]);
-			expect(await document.validate()).toEqual(expected);
+			expect(document.validate()).toEqual(expected);
 		});
 
-		test('should not return error if id match is specified and id matches pattern', async () => {
+		test('should not return error if id match is specified and id matches pattern', () => {
 			const document = new DocumentSubclass(schema, { data: { _id: 'foo', prop1: 'foo' } });
 
 			const expected = new Map();
-			expect(await document.validate()).toEqual(expected);
+			expect(document.validate()).toEqual(expected);
 		});
 	});
 
 	describe('schema type validation', () => {
-		test('should return error at property if schemaType validation fails', async () => {
+		test('should return error at property if schemaType validation fails', () => {
 			const definition: SchemaDefinition = {
 				prop1: { type: 'string', path: '1', required: true },
 			};
@@ -828,10 +828,10 @@ describe('validate', () => {
 			const document = new DocumentSubclass(schema, { record: [] });
 
 			const expected = new Map([['prop1', ['Property is required']]]);
-			expect(await document.validate()).toEqual(expected);
+			expect(document.validate()).toEqual(expected);
 		});
 
-		test('should not return error at property if schemaType validation is successful', async () => {
+		test('should not return error at property if schemaType validation is successful', () => {
 			const definition: SchemaDefinition = {
 				prop1: { type: 'string', path: '1', required: true },
 			};
@@ -839,7 +839,7 @@ describe('validate', () => {
 			const document = new DocumentSubclass(schema, { record: ['foo'] });
 
 			const expected = new Map();
-			expect(await document.validate()).toEqual(expected);
+			expect(document.validate()).toEqual(expected);
 		});
 
 		test('should return thrown error message in an array if schemaType validation throws an error', async () => {
@@ -863,10 +863,10 @@ describe('validate', () => {
 			const document = new DocumentSubclass(schema, { data: { prop1: 'foo' } });
 
 			const expected = new Map([['prop1', ['Test error message']]]);
-			expect(await document.validate()).toEqual(expected);
+			expect(document.validate()).toEqual(expected);
 		});
 
-		test('return error at property & unravel nested errors if schemaType validation fails', async () => {
+		test('return error at property & unravel nested errors if schemaType validation fails', () => {
 			const passingSchema = new Schema({
 				prop1: { type: 'string', path: '15', required: true },
 				prop2: { type: 'number', path: '16', dbDecimals: 2, required: true },
@@ -987,7 +987,7 @@ describe('validate', () => {
 				['failingSchemaDocumentArray.1.prop2', ['Property is required']],
 			]);
 
-			expect(await document.validate()).toEqual(expected);
+			expect(document.validate()).toEqual(expected);
 		});
 	});
 });

--- a/src/__tests__/compileModel.test.ts
+++ b/src/__tests__/compileModel.test.ts
@@ -664,7 +664,7 @@ describe('save', () => {
 		const id = 'id';
 		// @ts-expect-error: intentionally invalid data to trigger validation failure
 		const model = new Model({ _id: id, data: { prop1: 'prop1-value' } });
-		model.validate = () => Promise.resolve(new Map([['prop1', ['Not good']]]));
+		model.validate = () => new Map([['prop1', ['Not good']]]);
 
 		await expect(model.save()).rejects.toThrow(DataValidationError);
 	});

--- a/src/compileModel.ts
+++ b/src/compileModel.ts
@@ -350,7 +350,7 @@ const compileModel = <
 			}
 
 			// validate data prior to saving
-			const validationErrors = await this.validate();
+			const validationErrors = this.validate();
 			if (validationErrors.size > 0) {
 				throw new DataValidationError({
 					validationErrors,

--- a/src/schemaType/ArrayType.ts
+++ b/src/schemaType/ArrayType.ts
@@ -33,20 +33,16 @@ class ArrayType extends BaseScalarArrayType {
 	}
 
 	/** Validate the array */
-	public async validate(value: unknown): Promise<Map<string, string[]>> {
-		const errorsMap = new Map<string, string[]>();
-		await Promise.all(
-			ensureArray(value).map(async (arrayItem, index) => {
-				const result = await this.valueSchemaType.validate(arrayItem);
+	public validate(value: unknown): Map<string, string[]> {
+		return ensureArray(value).reduce<Map<string, string[]>>((acc, arrayItem, index) => {
+			const result = this.valueSchemaType.validate(arrayItem);
 
-				if (result.length > 0) {
-					const key = String(index);
-					errorsMap.set(key, result);
-				}
-			}),
-		);
-
-		return errorsMap;
+			if (result.length > 0) {
+				const key = String(index);
+				acc.set(key, result);
+			}
+			return acc;
+		}, new Map());
 	}
 }
 

--- a/src/schemaType/BaseSchemaType.ts
+++ b/src/schemaType/BaseSchemaType.ts
@@ -10,7 +10,7 @@ export interface SchemaTypeDefinitionBase {
 	encrypted?: boolean;
 }
 
-type ValidationFunction = (value: unknown) => boolean | Promise<boolean>;
+type ValidationFunction = (value: unknown) => boolean;
 
 export interface Validator {
 	validationFn: ValidationFunction;
@@ -63,7 +63,7 @@ abstract class BaseSchemaType {
 	public abstract set(record: MvRecord, value: unknown): MvRecord;
 
 	/** Validate value */
-	public abstract validate(value: unknown): Promise<string[] | Map<string, string[]>>;
+	public abstract validate(value: unknown): string[] | Map<string, string[]>;
 }
 
 export default BaseSchemaType;

--- a/src/schemaType/DocumentArrayType.ts
+++ b/src/schemaType/DocumentArrayType.ts
@@ -67,26 +67,19 @@ class DocumentArrayType<
 	}
 
 	/** Validate the document array */
-	public async validate(
-		documentList: Document<TSchema, TSchemaDefinition>[],
-	): Promise<Map<string, string[]>> {
-		// Create a map to store the errors. The key will be the index of the document in the list prefixed to the key path of the error
-		const errorsMap = new Map<string, string[]>();
-		await Promise.all(
-			documentList.map(async (document, index) => {
-				const documentErrors = await document.validate();
+	public validate(documentList: Document<TSchema, TSchemaDefinition>[]): Map<string, string[]> {
+		return documentList.reduce<Map<string, string[]>>((acc, document, index) => {
+			const documentErrors = document.validate();
 
-				const indexString = String(index);
-				documentErrors.forEach((messages, keyPath) => {
-					if (messages.length > 0) {
-						const errorsMapKey = `${indexString}.${keyPath}`;
-						errorsMap.set(errorsMapKey, messages);
-					}
-				});
-			}),
-		);
+			documentErrors.forEach((messages, keyPath) => {
+				if (messages.length > 0) {
+					const errorsMapKey = `${index}.${keyPath}`;
+					acc.set(errorsMapKey, messages);
+				}
+			});
 
-		return errorsMap;
+			return acc;
+		}, new Map());
 	}
 
 	/** Create an array of foreign key definitions that will be validated before save */

--- a/src/schemaType/EmbeddedType.ts
+++ b/src/schemaType/EmbeddedType.ts
@@ -54,7 +54,7 @@ class EmbeddedType<
 	}
 
 	/** Validate the embedded document */
-	public validate(document: Document<TSchema, TSchemaDefinition>): Promise<Map<string, string[]>> {
+	public validate(document: Document<TSchema, TSchemaDefinition>): Map<string, string[]> {
 		// - validation against the embedded document will return a single object with 0 to n keys - only those with keys indicate errors;
 		return document.validate();
 	}

--- a/src/schemaType/ISOCalendarDateTimeType.ts
+++ b/src/schemaType/ISOCalendarDateTimeType.ts
@@ -39,7 +39,7 @@ class ISOCalendarDateTimeType extends BaseScalarType {
 	}
 
 	/** ISOCalendarDateTime data type validator */
-	protected override validateType = async (value: unknown): Promise<boolean> => {
+	protected override validateType = (value: unknown): boolean => {
 		if (value == null) {
 			return true;
 		}
@@ -51,14 +51,10 @@ class ISOCalendarDateTimeType extends BaseScalarType {
 
 		const [datePart, timePart] = value.split('T');
 
-		const partsValidations = (
-			await Promise.all([
-				this.isoCalendarDateType.validate(datePart),
-				this.isoTimeType.validate(timePart),
-			])
-		).flat();
+		const dateValidationResult = this.isoCalendarDateType.validate(datePart);
+		const timeValidationResult = this.isoTimeType.validate(timePart);
 
-		return partsValidations.length === 0;
+		return dateValidationResult.length === 0 && timeValidationResult.length === 0;
 	};
 }
 

--- a/src/schemaType/__tests__/ArrayType.test.ts
+++ b/src/schemaType/__tests__/ArrayType.test.ts
@@ -190,7 +190,7 @@ describe('transformForeignKeyDefinitionsToDb', () => {
 });
 
 describe('validate', () => {
-	test('should return errors defined by value schema validators as a map with the index as the key and string array of errors as the value', async () => {
+	test('should return errors defined by value schema validators as a map with the index as the key and string array of errors as the value', () => {
 		const valueSchemaDefinition: SchemaTypeDefinitionNumber = {
 			type: 'number',
 			path: '2.2',
@@ -202,7 +202,7 @@ describe('validate', () => {
 
 		const value = [null, null, 1.23];
 
-		const validationResult = await arrayType.validate(value);
+		const validationResult = arrayType.validate(value);
 		const expected = new Map<string, string[]>([
 			['0', ['Property is required']],
 			['1', ['Property is required']],
@@ -210,7 +210,7 @@ describe('validate', () => {
 		expect(validationResult).toEqual(expected);
 	});
 
-	test('should have no errors if value schema validators pass', async () => {
+	test('should have no errors if value schema validators pass', () => {
 		const valueSchemaDefinition: SchemaTypeDefinitionNumber = {
 			type: 'number',
 			path: '2.2',
@@ -222,7 +222,7 @@ describe('validate', () => {
 
 		const value = [1.23, 4.56, 7.89];
 
-		const validationResult = await arrayType.validate(value);
+		const validationResult = arrayType.validate(value);
 		expect(validationResult.size).toBe(0);
 	});
 });

--- a/src/schemaType/__tests__/BaseScalarArrayType.test.ts
+++ b/src/schemaType/__tests__/BaseScalarArrayType.test.ts
@@ -42,8 +42,8 @@ class TestSubclass extends BaseScalarArrayType {
 		return value;
 	}
 
-	public validate(): Promise<string[]> {
-		return Promise.resolve([]);
+	public validate(): string[] {
+		return [];
 	}
 }
 

--- a/src/schemaType/__tests__/BaseScalarType.test.ts
+++ b/src/schemaType/__tests__/BaseScalarType.test.ts
@@ -192,7 +192,7 @@ describe('transformToQuery', () => {
 });
 
 describe('validate', () => {
-	test('should return error message if required is true and value is null', async () => {
+	test('should return error message if required is true and value is null', () => {
 		const definition: SchemaTypeDefinitionString = {
 			type: 'string',
 			path: '2',
@@ -203,10 +203,10 @@ describe('validate', () => {
 
 		const value = null;
 
-		expect(await testSubclass.validate(value)).toContain('Property is required');
+		expect(testSubclass.validate(value)).toContain('Property is required');
 	});
 
-	test('should not return error message if required is true and value is populated', async () => {
+	test('should not return error message if required is true and value is populated', () => {
 		const definition: SchemaTypeDefinitionString = {
 			type: 'string',
 			path: '2',
@@ -217,10 +217,10 @@ describe('validate', () => {
 
 		const value = 'foo';
 
-		expect(await testSubclass.validate(value)).not.toContain('Property is required');
+		expect(testSubclass.validate(value)).not.toContain('Property is required');
 	});
 
-	test('should not return error message if required is false and value is null', async () => {
+	test('should not return error message if required is false and value is null', () => {
 		const definition: SchemaTypeDefinitionString = {
 			type: 'string',
 			path: '2',
@@ -231,7 +231,7 @@ describe('validate', () => {
 
 		const value = null;
 
-		expect(await testSubclass.validate(value)).not.toContain('Property is required');
+		expect(testSubclass.validate(value)).not.toContain('Property is required');
 	});
 });
 

--- a/src/schemaType/__tests__/BaseSchemaType.test.ts
+++ b/src/schemaType/__tests__/BaseSchemaType.test.ts
@@ -11,7 +11,7 @@ class TestSubclass extends BaseSchemaType {
 	}
 
 	public validate() {
-		return Promise.resolve([]);
+		return [];
 	}
 }
 

--- a/src/schemaType/__tests__/BooleanType.test.ts
+++ b/src/schemaType/__tests__/BooleanType.test.ts
@@ -94,7 +94,7 @@ describe('transformToQuery', () => {
 
 describe('validations', () => {
 	describe('required validations', () => {
-		test('should return error message if required is true and value is null', async () => {
+		test('should return error message if required is true and value is null', () => {
 			const definition: SchemaTypeDefinitionBoolean = {
 				type: 'boolean',
 				path: '2',
@@ -104,10 +104,10 @@ describe('validations', () => {
 
 			const value = null;
 
-			expect(await booleanType.validate(value)).toContain('Property is required');
+			expect(booleanType.validate(value)).toContain('Property is required');
 		});
 
-		test('should not return error message if required is true and value is populated with a boolean value', async () => {
+		test('should not return error message if required is true and value is populated with a boolean value', () => {
 			const definition: SchemaTypeDefinitionBoolean = {
 				type: 'boolean',
 				path: '2',
@@ -117,10 +117,10 @@ describe('validations', () => {
 
 			const value = true;
 
-			expect(await booleanType.validate(value)).not.toContain('Property is required');
+			expect(booleanType.validate(value)).not.toContain('Property is required');
 		});
 
-		test('should not return error message if required is false and value is null', async () => {
+		test('should not return error message if required is false and value is null', () => {
 			const definition: SchemaTypeDefinitionBoolean = {
 				type: 'boolean',
 				path: '2',
@@ -130,7 +130,7 @@ describe('validations', () => {
 
 			const value = null;
 
-			expect(await booleanType.validate(value)).not.toContain('Property is required');
+			expect(booleanType.validate(value)).not.toContain('Property is required');
 		});
 	});
 });

--- a/src/schemaType/__tests__/DocumentArrayType.test.ts
+++ b/src/schemaType/__tests__/DocumentArrayType.test.ts
@@ -262,13 +262,13 @@ describe('validate', () => {
 	const valueSchema = new Schema(definition);
 	const documentArrayType = new DocumentArrayType(valueSchema);
 
-	test('should return a single Map for the errors encountered when validating each subdocument. prepending the index to the nested document key', async () => {
+	test('should return a single Map for the errors encountered when validating each subdocument. prepending the index to the nested document key', () => {
 		const originalRecord: MvRecord = ['unrelated'];
 
 		const value1 = Document.createSubdocumentFromRecord(valueSchema, originalRecord);
 		const value2 = Document.createSubdocumentFromRecord(valueSchema, originalRecord);
 
-		const validationResults = await documentArrayType.validate([value1, value2]);
+		const validationResults = documentArrayType.validate([value1, value2]);
 
 		const expected = new Map([
 			['0.prop1', ['Property is required']],
@@ -280,7 +280,7 @@ describe('validate', () => {
 		expect(validationResults).toEqual(expected);
 	});
 
-	test('should return an empty map with no errors when no errors reported', async () => {
+	test('should return an empty map with no errors when no errors reported', () => {
 		const originalRecord: MvRecord = ['unrelated'];
 		const value1 = Document.createSubdocumentFromRecord(valueSchema, originalRecord);
 		const value2 = Document.createSubdocumentFromRecord(valueSchema, originalRecord);
@@ -289,7 +289,7 @@ describe('validate', () => {
 		value2.prop1 = 'bar';
 		value2.prop2 = 4.56;
 
-		const validationResults = await documentArrayType.validate([value1, value2]);
+		const validationResults = documentArrayType.validate([value1, value2]);
 		expect(validationResults.size).toBe(0);
 	});
 });

--- a/src/schemaType/__tests__/EmbeddedType.test.ts
+++ b/src/schemaType/__tests__/EmbeddedType.test.ts
@@ -82,7 +82,7 @@ describe('validate', () => {
 	const valueSchema = new Schema(definition);
 	const embeddedType = new EmbeddedType(valueSchema);
 
-	test('should return a map of the errors encountered when validating the subdocument', async () => {
+	test('should return a map of the errors encountered when validating the subdocument', () => {
 		const originalRecord: MvRecord = ['unrelated'];
 		const value = Document.createSubdocumentFromRecord(valueSchema, originalRecord);
 
@@ -91,17 +91,17 @@ describe('validate', () => {
 			['prop2', ['Property is required']],
 		]);
 
-		const validationResults = await embeddedType.validate(value);
+		const validationResults = embeddedType.validate(value);
 		expect(validationResults).toEqual(expected);
 	});
 
-	test('should return an empty map if no errors are encountered when validating the subdocument', async () => {
+	test('should return an empty map if no errors are encountered when validating the subdocument', () => {
 		const originalRecord: MvRecord = ['unrelated'];
 		const value = Document.createSubdocumentFromRecord(valueSchema, originalRecord);
 		value.prop1 = 'foo';
 		value.prop2 = 12.34;
 
-		const validationResults = await embeddedType.validate(value);
+		const validationResults = embeddedType.validate(value);
 		expect(validationResults.size).toBe(0);
 	});
 });

--- a/src/schemaType/__tests__/ISOCalendarDateTimeType.test.ts
+++ b/src/schemaType/__tests__/ISOCalendarDateTimeType.test.ts
@@ -136,7 +136,7 @@ describe('transformToDb', () => {
 
 describe('validations', () => {
 	describe('required validations', () => {
-		test('should return error message if required is true and value is null', async () => {
+		test('should return error message if required is true and value is null', () => {
 			const definition: SchemaTypeDefinitionISOCalendarDateTime = {
 				type: 'ISOCalendarDateTime',
 				path: '2',
@@ -146,10 +146,10 @@ describe('validations', () => {
 
 			const value = null;
 
-			expect(await isoCalendarDateTimeType.validate(value)).toContain('Property is required');
+			expect(isoCalendarDateTimeType.validate(value)).toContain('Property is required');
 		});
 
-		test('should not return error message if required is true and value is populated with a date-time', async () => {
+		test('should not return error message if required is true and value is populated with a date-time', () => {
 			const definition: SchemaTypeDefinitionISOCalendarDateTime = {
 				type: 'ISOCalendarDateTime',
 				path: '2',
@@ -159,10 +159,10 @@ describe('validations', () => {
 
 			const value = '2022-02-27T12:12:12.000';
 
-			expect(await isoCalendarDateTimeType.validate(value)).not.toContain('Property is required');
+			expect(isoCalendarDateTimeType.validate(value)).not.toContain('Property is required');
 		});
 
-		test('should not return error message if required is false and value is null', async () => {
+		test('should not return error message if required is false and value is null', () => {
 			const definition: SchemaTypeDefinitionISOCalendarDateTime = {
 				type: 'ISOCalendarDateTime',
 				path: '2',
@@ -172,12 +172,12 @@ describe('validations', () => {
 
 			const value = null;
 
-			expect(await isoCalendarDateTimeType.validate(value)).not.toContain('Property is required');
+			expect(isoCalendarDateTimeType.validate(value)).not.toContain('Property is required');
 		});
 	});
 
 	describe('type validations', () => {
-		test('should not return error message if value is null', async () => {
+		test('should not return error message if value is null', () => {
 			const definition: SchemaTypeDefinitionISOCalendarDateTime = {
 				type: 'ISOCalendarDateTime',
 				path: '2',
@@ -186,12 +186,12 @@ describe('validations', () => {
 
 			const value = null;
 
-			expect(await isoCalendarDateTimeType.validate(value)).not.toContain(
+			expect(isoCalendarDateTimeType.validate(value)).not.toContain(
 				'Property cannot be cast into the defined type',
 			);
 		});
 
-		test('should return error message if value is not a string', async () => {
+		test('should return error message if value is not a string', () => {
 			const definition: SchemaTypeDefinitionISOCalendarDateTime = {
 				type: 'ISOCalendarDateTime',
 				path: '2',
@@ -200,12 +200,12 @@ describe('validations', () => {
 
 			const value = 1234;
 
-			expect(await isoCalendarDateTimeType.validate(value)).toContain(
+			expect(isoCalendarDateTimeType.validate(value)).toContain(
 				'Property cannot be cast into the defined type',
 			);
 		});
 
-		test('should return error message if date value is improperly formatted', async () => {
+		test('should return error message if date value is improperly formatted', () => {
 			const definition: SchemaTypeDefinitionISOCalendarDateTime = {
 				type: 'ISOCalendarDateTime',
 				path: '2',
@@ -214,12 +214,12 @@ describe('validations', () => {
 
 			const value = 'fooT12:12:12.123';
 
-			expect(await isoCalendarDateTimeType.validate(value)).toContain(
+			expect(isoCalendarDateTimeType.validate(value)).toContain(
 				'Property cannot be cast into the defined type',
 			);
 		});
 
-		test('should return error message if time value is improperly formatted', async () => {
+		test('should return error message if time value is improperly formatted', () => {
 			const definition: SchemaTypeDefinitionISOCalendarDateTime = {
 				type: 'ISOCalendarDateTime',
 				path: '2',
@@ -228,12 +228,12 @@ describe('validations', () => {
 
 			const value = '2022-02-27Tfoo';
 
-			expect(await isoCalendarDateTimeType.validate(value)).toContain(
+			expect(isoCalendarDateTimeType.validate(value)).toContain(
 				'Property cannot be cast into the defined type',
 			);
 		});
 
-		test('should not return error message if value is a properly formatted string', async () => {
+		test('should not return error message if value is a properly formatted string', () => {
 			const definition: SchemaTypeDefinitionISOCalendarDateTime = {
 				type: 'ISOCalendarDateTime',
 				path: '2',
@@ -242,7 +242,7 @@ describe('validations', () => {
 
 			const value = '2022-02-27T12:12:12.123';
 
-			expect(await isoCalendarDateTimeType.validate(value)).not.toContain(
+			expect(isoCalendarDateTimeType.validate(value)).not.toContain(
 				'Property cannot be cast into the defined type',
 			);
 		});

--- a/src/schemaType/__tests__/ISOCalendarDateType.test.ts
+++ b/src/schemaType/__tests__/ISOCalendarDateType.test.ts
@@ -74,7 +74,7 @@ describe('transformToDb', () => {
 
 describe('validations', () => {
 	describe('required validations', () => {
-		test('should return error message if required is true and value is null', async () => {
+		test('should return error message if required is true and value is null', () => {
 			const definition: SchemaTypeDefinitionISOCalendarDate = {
 				type: 'ISOCalendarDate',
 				path: '2',
@@ -84,10 +84,10 @@ describe('validations', () => {
 
 			const value = null;
 
-			expect(await isoCalendarDateType.validate(value)).toContain('Property is required');
+			expect(isoCalendarDateType.validate(value)).toContain('Property is required');
 		});
 
-		test('should not return error message if required is true and value is populated with a date', async () => {
+		test('should not return error message if required is true and value is populated with a date', () => {
 			const definition: SchemaTypeDefinitionISOCalendarDate = {
 				type: 'ISOCalendarDate',
 				path: '2',
@@ -97,10 +97,10 @@ describe('validations', () => {
 
 			const value = '2022-02-27';
 
-			expect(await isoCalendarDateType.validate(value)).not.toContain('Property is required');
+			expect(isoCalendarDateType.validate(value)).not.toContain('Property is required');
 		});
 
-		test('should not return error message if required is false and value is null', async () => {
+		test('should not return error message if required is false and value is null', () => {
 			const definition: SchemaTypeDefinitionISOCalendarDate = {
 				type: 'ISOCalendarDate',
 				path: '2',
@@ -110,12 +110,12 @@ describe('validations', () => {
 
 			const value = null;
 
-			expect(await isoCalendarDateType.validate(value)).not.toContain('Property is required');
+			expect(isoCalendarDateType.validate(value)).not.toContain('Property is required');
 		});
 	});
 
 	describe('type validations', () => {
-		test('should not return error message if value is null', async () => {
+		test('should not return error message if value is null', () => {
 			const definition: SchemaTypeDefinitionISOCalendarDate = {
 				type: 'ISOCalendarDate',
 				path: '2',
@@ -124,12 +124,12 @@ describe('validations', () => {
 
 			const value = null;
 
-			expect(await isoCalendarDateType.validate(value)).not.toContain(
+			expect(isoCalendarDateType.validate(value)).not.toContain(
 				'Property cannot be cast into the defined type',
 			);
 		});
 
-		test('should return error message if value is not a string', async () => {
+		test('should return error message if value is not a string', () => {
 			const definition: SchemaTypeDefinitionISOCalendarDate = {
 				type: 'ISOCalendarDate',
 				path: '2',
@@ -138,12 +138,12 @@ describe('validations', () => {
 
 			const value = 1234;
 
-			expect(await isoCalendarDateType.validate(value)).toContain(
+			expect(isoCalendarDateType.validate(value)).toContain(
 				'Property cannot be cast into the defined type',
 			);
 		});
 
-		test('should return error message if value is an improperly formatted string', async () => {
+		test('should return error message if value is an improperly formatted string', () => {
 			const definition: SchemaTypeDefinitionISOCalendarDate = {
 				type: 'ISOCalendarDate',
 				path: '2',
@@ -152,12 +152,12 @@ describe('validations', () => {
 
 			const value = 'foo';
 
-			expect(await isoCalendarDateType.validate(value)).toContain(
+			expect(isoCalendarDateType.validate(value)).toContain(
 				'Property cannot be cast into the defined type',
 			);
 		});
 
-		test('should return error message if value is an invalid date', async () => {
+		test('should return error message if value is an invalid date', () => {
 			const definition: SchemaTypeDefinitionISOCalendarDate = {
 				type: 'ISOCalendarDate',
 				path: '2',
@@ -166,12 +166,12 @@ describe('validations', () => {
 
 			const value = '2022-02-31'; // only 28 days in month
 
-			expect(await isoCalendarDateType.validate(value)).toContain(
+			expect(isoCalendarDateType.validate(value)).toContain(
 				'Property cannot be cast into the defined type',
 			);
 		});
 
-		test('should not return error message if value is a properly formatted string', async () => {
+		test('should not return error message if value is a properly formatted string', () => {
 			const definition: SchemaTypeDefinitionISOCalendarDate = {
 				type: 'ISOCalendarDate',
 				path: '2',
@@ -180,7 +180,7 @@ describe('validations', () => {
 
 			const value = '2022-02-27';
 
-			expect(await isoCalendarDateType.validate(value)).not.toContain(
+			expect(isoCalendarDateType.validate(value)).not.toContain(
 				'Property cannot be cast into the defined type',
 			);
 		});

--- a/src/schemaType/__tests__/ISOTimeType.test.ts
+++ b/src/schemaType/__tests__/ISOTimeType.test.ts
@@ -162,7 +162,7 @@ describe('transformToDb', () => {
 
 describe('validations', () => {
 	describe('required validations', () => {
-		test('should return error message if required is true and value is null', async () => {
+		test('should return error message if required is true and value is null', () => {
 			const definition: SchemaTypeDefinitionISOTime = {
 				type: 'ISOTime',
 				path: '2',
@@ -172,10 +172,10 @@ describe('validations', () => {
 
 			const value = null;
 
-			expect(await isoTimeType.validate(value)).toContain('Property is required');
+			expect(isoTimeType.validate(value)).toContain('Property is required');
 		});
 
-		test('should not return error message if required is true and value is populated with a time', async () => {
+		test('should not return error message if required is true and value is populated with a time', () => {
 			const definition: SchemaTypeDefinitionISOTime = {
 				type: 'ISOTime',
 				path: '2',
@@ -185,10 +185,10 @@ describe('validations', () => {
 
 			const value = '12:00:00.000';
 
-			expect(await isoTimeType.validate(value)).not.toContain('Property is required');
+			expect(isoTimeType.validate(value)).not.toContain('Property is required');
 		});
 
-		test('should not return error message if required is false and value is null', async () => {
+		test('should not return error message if required is false and value is null', () => {
 			const definition: SchemaTypeDefinitionISOTime = {
 				type: 'ISOTime',
 				path: '2',
@@ -198,12 +198,12 @@ describe('validations', () => {
 
 			const value = null;
 
-			expect(await isoTimeType.validate(value)).not.toContain('Property is required');
+			expect(isoTimeType.validate(value)).not.toContain('Property is required');
 		});
 	});
 
 	describe('type validations', () => {
-		test('should not return error message if value is null', async () => {
+		test('should not return error message if value is null', () => {
 			const definition: SchemaTypeDefinitionISOTime = {
 				type: 'ISOTime',
 				path: '2',
@@ -212,12 +212,12 @@ describe('validations', () => {
 
 			const value = null;
 
-			expect(await isoTimeType.validate(value)).not.toContain(
+			expect(isoTimeType.validate(value)).not.toContain(
 				'Property cannot be cast into the defined type',
 			);
 		});
 
-		test('should return error message if value is not a string', async () => {
+		test('should return error message if value is not a string', () => {
 			const definition: SchemaTypeDefinitionISOTime = {
 				type: 'ISOTime',
 				path: '2',
@@ -226,12 +226,12 @@ describe('validations', () => {
 
 			const value = 1234;
 
-			expect(await isoTimeType.validate(value)).toContain(
+			expect(isoTimeType.validate(value)).toContain(
 				'Property cannot be cast into the defined type',
 			);
 		});
 
-		test('should return error message if value is an improperly formatted string', async () => {
+		test('should return error message if value is an improperly formatted string', () => {
 			const definition: SchemaTypeDefinitionISOTime = {
 				type: 'ISOTime',
 				path: '2',
@@ -240,12 +240,12 @@ describe('validations', () => {
 
 			const value = 'foo';
 
-			expect(await isoTimeType.validate(value)).toContain(
+			expect(isoTimeType.validate(value)).toContain(
 				'Property cannot be cast into the defined type',
 			);
 		});
 
-		test('should not return error message if value is a properly formatted string', async () => {
+		test('should not return error message if value is a properly formatted string', () => {
 			const definition: SchemaTypeDefinitionISOTime = {
 				type: 'ISOTime',
 				path: '2',
@@ -254,7 +254,7 @@ describe('validations', () => {
 
 			const value = '12:01:02.123';
 
-			expect(await isoTimeType.validate(value)).not.toContain(
+			expect(isoTimeType.validate(value)).not.toContain(
 				'Property cannot be cast into the defined type',
 			);
 		});

--- a/src/schemaType/__tests__/NestedArrayType.test.ts
+++ b/src/schemaType/__tests__/NestedArrayType.test.ts
@@ -171,7 +171,7 @@ describe('transformForeignKeyDefinitionsToDb', () => {
 });
 
 describe('validate', () => {
-	test('should return errors defined by value schema validators when data is an un-nested array', async () => {
+	test('should return errors defined by value schema validators when data is an un-nested array', () => {
 		const valueSchemaDefinition: SchemaTypeDefinitionNumber = {
 			type: 'number',
 			path: '2.2',
@@ -188,12 +188,12 @@ describe('validate', () => {
 			['1.0', ['Property is required']],
 		]);
 
-		const validationResult = await nestedArrayType.validate(value);
+		const validationResult = nestedArrayType.validate(value);
 		expect(validationResult).toEqual(expected);
 		expect(validationResult.size).toBe(2);
 	});
 
-	test('should return errors defined by value schema validators when data is a nested array', async () => {
+	test('should return errors defined by value schema validators when data is a nested array', () => {
 		const valueSchemaDefinition: SchemaTypeDefinitionNumber = {
 			type: 'number',
 			path: '2.2',
@@ -215,12 +215,12 @@ describe('validate', () => {
 			['1.0', ['Property is required']],
 			['1.1', ['Property is required']],
 		]);
-		const validationResult = await nestedArrayType.validate(value);
+		const validationResult = nestedArrayType.validate(value);
 		expect(validationResult).toEqual(expected);
 		expect(validationResult.size).toBe(4);
 	});
 
-	test('should have no errors if value schema validators pass', async () => {
+	test('should have no errors if value schema validators pass', () => {
 		const valueSchemaDefinition: SchemaTypeDefinitionNumber = {
 			type: 'number',
 			path: '2.2',
@@ -235,7 +235,7 @@ describe('validate', () => {
 			[7.89, 12.34],
 		];
 
-		const validationResult = await nestedArrayType.validate(value);
+		const validationResult = nestedArrayType.validate(value);
 		expect(validationResult.size).toBe(0);
 	});
 });

--- a/src/schemaType/__tests__/NumberType.test.ts
+++ b/src/schemaType/__tests__/NumberType.test.ts
@@ -129,7 +129,7 @@ describe('transformToDb', () => {
 
 describe('validations', () => {
 	describe('required validations', () => {
-		test('should return error message if required is true and value is null', async () => {
+		test('should return error message if required is true and value is null', () => {
 			const definition: SchemaTypeDefinitionNumber = {
 				type: 'number',
 				path: '2',
@@ -139,10 +139,10 @@ describe('validations', () => {
 
 			const value = null;
 
-			expect(await numberType.validate(value)).toContain('Property is required');
+			expect(numberType.validate(value)).toContain('Property is required');
 		});
 
-		test('should not return error message if required is true and value is populated with a number', async () => {
+		test('should not return error message if required is true and value is populated with a number', () => {
 			const definition: SchemaTypeDefinitionNumber = {
 				type: 'number',
 				path: '2',
@@ -152,10 +152,10 @@ describe('validations', () => {
 
 			const value = 1234;
 
-			expect(await numberType.validate(value)).not.toContain('Property is required');
+			expect(numberType.validate(value)).not.toContain('Property is required');
 		});
 
-		test('should not return error message if required is false and value is null', async () => {
+		test('should not return error message if required is false and value is null', () => {
 			const definition: SchemaTypeDefinitionNumber = {
 				type: 'number',
 				path: '2',
@@ -165,12 +165,12 @@ describe('validations', () => {
 
 			const value = null;
 
-			expect(await numberType.validate(value)).not.toContain('Property is required');
+			expect(numberType.validate(value)).not.toContain('Property is required');
 		});
 	});
 
 	describe('type validations', () => {
-		test('should return error message if value is not a number', async () => {
+		test('should return error message if value is not a number', () => {
 			const definition: SchemaTypeDefinitionNumber = {
 				type: 'number',
 				path: '2',
@@ -180,12 +180,10 @@ describe('validations', () => {
 
 			const value = 'foo';
 
-			expect(await numberType.validate(value)).toContain(
-				'Property cannot be cast into the defined type',
-			);
+			expect(numberType.validate(value)).toContain('Property cannot be cast into the defined type');
 		});
 
-		test('should not return error message if value is a number', async () => {
+		test('should not return error message if value is a number', () => {
 			const definition: SchemaTypeDefinitionNumber = {
 				type: 'number',
 				path: '2',
@@ -195,7 +193,7 @@ describe('validations', () => {
 
 			const value = 1234;
 
-			expect(await numberType.validate(value)).not.toContain(
+			expect(numberType.validate(value)).not.toContain(
 				'Property cannot be cast into the defined type',
 			);
 		});

--- a/src/schemaType/__tests__/StringType.test.ts
+++ b/src/schemaType/__tests__/StringType.test.ts
@@ -108,7 +108,7 @@ describe('transformForeignKeyDefinitionsToDb', () => {
 
 describe('validations', () => {
 	describe('required validations', () => {
-		test('should return error message if required is true and value is null', async () => {
+		test('should return error message if required is true and value is null', () => {
 			const definition: SchemaTypeDefinitionString = {
 				type: 'string',
 				path: '2',
@@ -118,10 +118,10 @@ describe('validations', () => {
 
 			const value = null;
 
-			expect(await stringType.validate(value)).toContain('Property is required');
+			expect(stringType.validate(value)).toContain('Property is required');
 		});
 
-		test('should return error message if required is true and value is empty string', async () => {
+		test('should return error message if required is true and value is empty string', () => {
 			const definition: SchemaTypeDefinitionString = {
 				type: 'string',
 				path: '2',
@@ -131,10 +131,10 @@ describe('validations', () => {
 
 			const value = '';
 
-			expect(await stringType.validate(value)).toContain('Property is required');
+			expect(stringType.validate(value)).toContain('Property is required');
 		});
 
-		test('should not return error message if required is true and value is populated with a string', async () => {
+		test('should not return error message if required is true and value is populated with a string', () => {
 			const definition: SchemaTypeDefinitionString = {
 				type: 'string',
 				path: '2',
@@ -144,10 +144,10 @@ describe('validations', () => {
 
 			const value = 'foo';
 
-			expect(await stringType.validate(value)).not.toContain('Property is required');
+			expect(stringType.validate(value)).not.toContain('Property is required');
 		});
 
-		test('should not return error message if required is false and value is null', async () => {
+		test('should not return error message if required is false and value is null', () => {
 			const definition: SchemaTypeDefinitionString = {
 				type: 'string',
 				path: '2',
@@ -157,10 +157,10 @@ describe('validations', () => {
 
 			const value = null;
 
-			expect(await stringType.validate(value)).not.toContain('Property is required');
+			expect(stringType.validate(value)).not.toContain('Property is required');
 		});
 
-		test('should not return error message if required is false and value is empty string', async () => {
+		test('should not return error message if required is false and value is empty string', () => {
 			const definition: SchemaTypeDefinitionString = {
 				type: 'string',
 				path: '2',
@@ -170,12 +170,12 @@ describe('validations', () => {
 
 			const value = '';
 
-			expect(await stringType.validate(value)).not.toContain('Property is required');
+			expect(stringType.validate(value)).not.toContain('Property is required');
 		});
 	});
 
 	describe('enum validations', () => {
-		test('should not return error message if value is null', async () => {
+		test('should not return error message if value is null', () => {
 			const definition: SchemaTypeDefinitionString = {
 				type: 'string',
 				path: '2',
@@ -185,12 +185,12 @@ describe('validations', () => {
 
 			const value = null;
 
-			expect(await stringType.validate(value)).not.toContain(
+			expect(stringType.validate(value)).not.toContain(
 				'Value not present in list of allowed values',
 			);
 		});
 
-		test('should not return error message if enum is null', async () => {
+		test('should not return error message if enum is null', () => {
 			const definition: SchemaTypeDefinitionString = {
 				type: 'string',
 				path: '2',
@@ -199,12 +199,12 @@ describe('validations', () => {
 
 			const value = 'foo';
 
-			expect(await stringType.validate(value)).not.toContain(
+			expect(stringType.validate(value)).not.toContain(
 				'Value not present in list of allowed values',
 			);
 		});
 
-		test('should not return error message if enum is defined and value is in enum', async () => {
+		test('should not return error message if enum is defined and value is in enum', () => {
 			const definition: SchemaTypeDefinitionString = {
 				type: 'string',
 				path: '2',
@@ -214,12 +214,12 @@ describe('validations', () => {
 
 			const value = 'foo';
 
-			expect(await stringType.validate(value)).not.toContain(
+			expect(stringType.validate(value)).not.toContain(
 				'Value not present in list of allowed values',
 			);
 		});
 
-		test('should return error message if enum is defined and value is not in enum', async () => {
+		test('should return error message if enum is defined and value is not in enum', () => {
 			const definition: SchemaTypeDefinitionString = {
 				type: 'string',
 				path: '2',
@@ -229,14 +229,12 @@ describe('validations', () => {
 
 			const value = 'baz';
 
-			expect(await stringType.validate(value)).toContain(
-				'Value not present in list of allowed values',
-			);
+			expect(stringType.validate(value)).toContain('Value not present in list of allowed values');
 		});
 	});
 
 	describe('regex validations', () => {
-		test('should not return error message if value is null', async () => {
+		test('should not return error message if value is null', () => {
 			const definition: SchemaTypeDefinitionString = {
 				type: 'string',
 				path: '2',
@@ -246,10 +244,10 @@ describe('validations', () => {
 
 			const value = null;
 
-			expect(await stringType.validate(value)).not.toContain('Value does not match pattern');
+			expect(stringType.validate(value)).not.toContain('Value does not match pattern');
 		});
 
-		test('should not return error message if match qualifier is null', async () => {
+		test('should not return error message if match qualifier is null', () => {
 			const definition: SchemaTypeDefinitionString = {
 				type: 'string',
 				path: '2',
@@ -258,10 +256,10 @@ describe('validations', () => {
 
 			const value = 'foo';
 
-			expect(await stringType.validate(value)).not.toContain('Value does not match pattern');
+			expect(stringType.validate(value)).not.toContain('Value does not match pattern');
 		});
 
-		test('should not return error message if value matches match qualifier', async () => {
+		test('should not return error message if value matches match qualifier', () => {
 			const definition: SchemaTypeDefinitionString = {
 				type: 'string',
 				path: '2',
@@ -271,10 +269,10 @@ describe('validations', () => {
 
 			const value = 'foo';
 
-			expect(await stringType.validate(value)).not.toContain('Value does not match pattern');
+			expect(stringType.validate(value)).not.toContain('Value does not match pattern');
 		});
 
-		test('should return error message if match qualifier is defined and value does not match', async () => {
+		test('should return error message if match qualifier is defined and value does not match', () => {
 			const definition: SchemaTypeDefinitionString = {
 				type: 'string',
 				path: '2',
@@ -284,7 +282,7 @@ describe('validations', () => {
 
 			const value = 'bar';
 
-			expect(await stringType.validate(value)).toContain('Value does not match pattern');
+			expect(stringType.validate(value)).toContain('Value does not match pattern');
 		});
 	});
 });


### PR DESCRIPTION
Currently, the document and schema type validators are asynchronous. When validating a document, this could result in an incredibly large number of asynchronous validations and therefore an equivalently large number of Promises. The volume of validations goes hand in hand with the total number of properties in a Document which, especially when factoring in DocumentArrays, might number in the many thousands or more.

However, none of the existing validators are asynchronous. The async functionality was created for a future use case that, to date, has not come.

I did a JS performance test and found that an array of 1000 items can be processed 217x faster with a synchronous function vs. an identical async function that doesn't do anything requiring async. Therefore, the supporting of async is reducing performance without any benefits.

This PR changes the `Document` and various schema type validations to no longer be async. If, in the future, async validation becomes necessary, we should consider a mechanism where the async validators will be kept independent of any synchronous validators.