### PR TITLE
Allow bypassing deployment validation and expose basic subroutine name on connection instance

### DIFF
--- a/src/Connection.ts
+++ b/src/Connection.ts
@@ -79,7 +79,6 @@ interface ConnectionConstructorOptions {
 }
 
 export enum ConnectionStatus {
-	// convert to enum when transitioning class to TS
 	disconnected = 'disconnected',
 	connected = 'connected',
 	connecting = 'connecting',

--- a/src/Connection.ts
+++ b/src/Connection.ts
@@ -177,6 +177,11 @@ class Connection {
 		this.logHandler.debug('creating new connection instance');
 	}
 
+	/** Returns the subroutine name that is used on the multivalue server */
+	public get subroutineName(): string {
+		return this.deploymentManager.subroutineName;
+	}
+
 	/** Create a connection */
 	public static createConnection(
 		/** URL of the MVIS which facilitates access to the mv database */
@@ -304,11 +309,7 @@ class Connection {
 		try {
 			response = await this.axiosInstance.post<
 				DbSubroutineResponseTypes | DbSubroutineResponseError
-			>(
-				this.deploymentManager.subroutineName,
-				{ input: data },
-				{ headers: { 'X-MVIS-Trace-Id': requestId } },
-			);
+			>(this.subroutineName, { input: data }, { headers: { 'X-MVIS-Trace-Id': requestId } });
 		} catch (err) {
 			return axios.isAxiosError(err) ? this.handleAxiosError(err) : this.handleUnexpectedError(err);
 		}

--- a/src/__tests__/Connection.test.ts
+++ b/src/__tests__/Connection.test.ts
@@ -27,7 +27,8 @@ import type { Logger } from '../LogHandler';
 jest.mock('axios');
 jest.mock('crypto');
 
-const mockDeploymentManager = mock<DeploymentManager>();
+const subroutineName = 'mvom_main@01234567';
+const mockDeploymentManager = mock<DeploymentManager>({ subroutineName });
 jest.mock('../DeploymentManager', () => ({ createDeploymentManager: () => mockDeploymentManager }));
 
 const mockedAxios = axios as jest.Mocked<typeof axios>;
@@ -206,6 +207,20 @@ describe('createConnection', () => {
 		expect(mockedAxios.create).toHaveBeenCalledWith(
 			expect.objectContaining({ httpsAgent: httpsAgentMock }),
 		);
+	});
+});
+
+describe('subroutineName getter', () => {
+	test('should return the subroutine name', () => {
+		const connection = Connection.createConnection(
+			mvisUrl,
+			mvisAdminUrl,
+			mvisAdminUsername,
+			mvisAdminPassword,
+			account,
+		);
+
+		expect(connection.subroutineName).toBe(subroutineName);
 	});
 });
 
@@ -430,7 +445,7 @@ describe('executeDbSubroutine', () => {
 
 		await connection.open();
 		expect(mockedAxiosInstance.post).toHaveBeenCalledWith(
-			expect.anything(),
+			subroutineName,
 			{
 				input: {
 					subroutineId: 'getServerInfo',


### PR DESCRIPTION
This PR makes the following changes:

#### Allow bypassing deployment validation
A new `validateDeployment` property has been added to the `open` method options on the `Connection` class. This option, which defaults to `true`, indicates that the database server's required mvom subroutine will be validated prior to opening the connection. This validation consists of checks to ensure that the MVIS subroutine definition exists and that the subroutine has been cataloged on the server.

If this option is overridden to `false`, this check will be bypassed and the connection will attempt to be opened.

#### Expose multivalue subroutine name on `Connection`
A new public property has been added to the `Connection` object named `subroutineName`. This is a public getter which will return the name of the subroutine as determined by the `DeploymentManager` instance associated with the `Connection`. This property can be accessed by consumers to determine what the name of the subroutine used by mvom when communicating through MVIS to the database server is.