### PR TITLE
Eliminate unnecessary TSchemaDefinition generics

### DIFF
--- a/src/Connection.ts
+++ b/src/Connection.ts
@@ -350,10 +350,10 @@ class Connection {
 	}
 
 	/** Define a new model */
-	public model<
-		TSchema extends Schema<TSchemaDefinition> | null,
-		TSchemaDefinition extends SchemaDefinition,
-	>(schema: TSchema, file: string): ModelConstructor<TSchema, TSchemaDefinition> {
+	public model<TSchema extends Schema<SchemaDefinition> | null>(
+		schema: TSchema,
+		file: string,
+	): ModelConstructor<TSchema> {
 		if (this.status !== ConnectionStatus.connected || this.dbServerInfo == null) {
 			this.logHandler.error('Cannot create model until database connection has been established');
 			throw new Error('Cannot create model until database connection has been established');

--- a/src/Document.ts
+++ b/src/Document.ts
@@ -7,16 +7,11 @@ import type { DbServerDelimiters, MvRecord } from './types';
 
 // #region Types
 /** Type of data property for constructing a document dependent upon the schema */
-export type DocumentData<
-	TSchema extends Schema<TSchemaDefinition> | null,
-	TSchemaDefinition extends SchemaDefinition,
-> = TSchema extends Schema<TSchemaDefinition> ? InferDocumentObject<TSchema> : never;
+export type DocumentData<TSchema extends Schema<SchemaDefinition> | null> =
+	TSchema extends Schema<SchemaDefinition> ? InferDocumentObject<TSchema> : never;
 
-export interface DocumentConstructorOptions<
-	TSchema extends Schema<TSchemaDefinition> | null,
-	TSchemaDefinition extends SchemaDefinition,
-> {
-	data?: DocumentData<TSchema, TSchemaDefinition>;
+export interface DocumentConstructorOptions<TSchema extends Schema<SchemaDefinition> | null> {
+	data?: DocumentData<TSchema>;
 	record?: MvRecord;
 	isSubdocument?: boolean;
 }
@@ -31,23 +26,17 @@ export interface BuildForeignKeyDefinitionsResult {
  * An intersection type that combines the `Document` class instance with the
  * inferred shape of the document object based on the schema definition.
  */
-type DocumentCompositeValue<
-	TSchema extends Schema<TSchemaDefinition> | null,
-	TSchemaDefinition extends SchemaDefinition,
-> =
-	TSchema extends Schema<TSchemaDefinition>
-		? Document<TSchema, TSchemaDefinition> & InferDocumentObject<TSchema>
-		: Document<TSchema, TSchemaDefinition>;
+type DocumentCompositeValue<TSchema extends Schema<SchemaDefinition> | null> =
+	TSchema extends Schema<SchemaDefinition>
+		? Document<TSchema> & InferDocumentObject<TSchema>
+		: Document<TSchema>;
 // #endregion
 
 /** A document object */
-class Document<
-	TSchema extends Schema<TSchemaDefinition> | null,
-	TSchemaDefinition extends SchemaDefinition,
-> {
+class Document<TSchema extends Schema<SchemaDefinition> | null> {
 	[key: string]: unknown;
 
-	public _raw: TSchema extends Schema<TSchemaDefinition> ? undefined : MvRecord;
+	public _raw: TSchema extends Schema<SchemaDefinition> ? undefined : MvRecord;
 
 	/** Array of any errors which occurred during transformation from the database */
 	public _transformationErrors: TransformDataError[];
@@ -61,10 +50,7 @@ class Document<
 	/** Indicates whether this document is a subdocument of a composing parent */
 	readonly #isSubdocument: boolean;
 
-	protected constructor(
-		schema: TSchema,
-		options: DocumentConstructorOptions<TSchema, TSchemaDefinition>,
-	) {
+	protected constructor(schema: TSchema, options: DocumentConstructorOptions<TSchema>) {
 		const { data = {}, record, isSubdocument = false } = options;
 
 		this.#schema = schema;
@@ -78,7 +64,7 @@ class Document<
 
 		this._raw = (
 			schema == null ? this.#record : undefined
-		) as TSchema extends Schema<TSchemaDefinition> ? undefined : MvRecord;
+		) as TSchema extends Schema<SchemaDefinition> ? undefined : MvRecord;
 
 		this.#transformRecordToDocument();
 
@@ -87,42 +73,30 @@ class Document<
 	}
 
 	/** Create a new Subdocument instance from a record array */
-	public static createSubdocumentFromRecord<
-		TSchema extends Schema<TSchemaDefinition> | null,
-		TSchemaDefinition extends SchemaDefinition,
-	>(schema: TSchema, record: MvRecord): DocumentCompositeValue<TSchema, TSchemaDefinition> {
-		return new Document(schema, { record, isSubdocument: true }) as DocumentCompositeValue<
-			TSchema,
-			TSchemaDefinition
-		>;
+	public static createSubdocumentFromRecord<TSchema extends Schema<SchemaDefinition> | null>(
+		schema: TSchema,
+		record: MvRecord,
+	): DocumentCompositeValue<TSchema> {
+		return new Document(schema, { record, isSubdocument: true }) as DocumentCompositeValue<TSchema>;
 	}
 
 	/** Create a new Subdocument instance from data */
-	public static createSubdocumentFromData<
-		TSchema extends Schema<TSchemaDefinition>,
-		TSchemaDefinition extends SchemaDefinition,
-	>(
+	public static createSubdocumentFromData<TSchema extends Schema<SchemaDefinition>>(
 		schema: TSchema,
-		data: DocumentData<TSchema, TSchemaDefinition>,
-	): DocumentCompositeValue<TSchema, TSchemaDefinition> {
-		return new Document(schema, { data, isSubdocument: true }) as DocumentCompositeValue<
-			TSchema,
-			TSchemaDefinition
-		>;
+		data: DocumentData<TSchema>,
+	): DocumentCompositeValue<TSchema> {
+		return new Document(schema, { data, isSubdocument: true }) as DocumentCompositeValue<TSchema>;
 	}
 
 	/** Create a new Document instance from a record string */
-	public static createDocumentFromRecordString<
-		TSchema extends Schema<TSchemaDefinition> | null,
-		TSchemaDefinition extends SchemaDefinition,
-	>(
+	public static createDocumentFromRecordString<TSchema extends Schema<SchemaDefinition> | null>(
 		schema: TSchema,
 		recordString: string,
 		dbServerDelimiters: DbServerDelimiters,
-	): DocumentCompositeValue<TSchema, TSchemaDefinition> {
+	): DocumentCompositeValue<TSchema> {
 		const record = Document.convertMvStringToArray(recordString, dbServerDelimiters);
 
-		return new Document(schema, { record }) as DocumentCompositeValue<TSchema, TSchemaDefinition>;
+		return new Document(schema, { record }) as DocumentCompositeValue<TSchema>;
 	}
 
 	/** Convert a multivalue string to an array */

--- a/src/Schema.ts
+++ b/src/Schema.ts
@@ -334,7 +334,7 @@ class Schema<TSchemaDefinition extends SchemaDefinition> {
 	private castArray(
 		castee: SchemaTypeDefinitionArray,
 		keyPath: string,
-	): ArrayType | NestedArrayType | DocumentArrayType<Schema<SchemaDefinition>, SchemaDefinition> {
+	): ArrayType | NestedArrayType | DocumentArrayType<Schema<SchemaDefinition>> {
 		if (castee.length !== 1) {
 			// a schema array definition must contain exactly one value of language-type object (which includes arrays)
 			throw new InvalidParameterError({

--- a/src/__tests__/Document.test.ts
+++ b/src/__tests__/Document.test.ts
@@ -8,14 +8,8 @@ import type { Assert, MvRecord } from '../types';
 
 const { am, vm, svm } = mockDelimiters;
 
-class DocumentSubclass<
-	TSchema extends Schema<TSchemaDefinition> | null,
-	TSchemaDefinition extends SchemaDefinition,
-> extends Document<TSchema, TSchemaDefinition> {
-	public constructor(
-		schema: TSchema,
-		options: DocumentConstructorOptions<TSchema, TSchemaDefinition>,
-	) {
+class DocumentSubclass<TSchema extends Schema<SchemaDefinition> | null> extends Document<TSchema> {
+	public constructor(schema: TSchema, options: DocumentConstructorOptions<TSchema>) {
 		super(schema, options);
 	}
 }

--- a/src/schemaType/DocumentArrayType.ts
+++ b/src/schemaType/DocumentArrayType.ts
@@ -8,10 +8,7 @@ import { ensureArray } from '../utils';
 import BaseSchemaType from './BaseSchemaType';
 
 /** A Document Array Schema Type */
-class DocumentArrayType<
-	TSchema extends Schema<TSchemaDefinition>,
-	TSchemaDefinition extends SchemaDefinition,
-> extends BaseSchemaType {
+class DocumentArrayType<TSchema extends Schema<SchemaDefinition>> extends BaseSchemaType {
 	/** An instance of Schema representing the document structure of the array's contents */
 	private readonly valueSchema: TSchema;
 
@@ -24,7 +21,7 @@ class DocumentArrayType<
 	 * Cast to array of documents
 	 * @throws {@link TypeError} Throws if a non-null/non-object is passed
 	 */
-	public override cast(value: unknown): Document<TSchema, TSchemaDefinition>[] {
+	public override cast(value: unknown): Document<TSchema>[] {
 		if (value == null) {
 			return [];
 		}
@@ -40,15 +37,12 @@ class DocumentArrayType<
 	}
 
 	/** Get value from mv data */
-	public get(record: MvRecord): Document<TSchema, TSchemaDefinition>[] {
+	public get(record: MvRecord): Document<TSchema>[] {
 		return [...this.makeSubDocument(record)];
 	}
 
 	/** Set specified document array value into mv record */
-	public set(
-		originalRecord: MvRecord,
-		documents: Document<TSchema, TSchemaDefinition>[],
-	): MvRecord {
+	public set(originalRecord: MvRecord, documents: Document<TSchema>[]): MvRecord {
 		const record = cloneDeep(originalRecord);
 		const mvPaths = this.valueSchema.getMvPaths();
 		// A subdocumentArray is always overwritten entirely so clear out all associated fields
@@ -67,7 +61,7 @@ class DocumentArrayType<
 	}
 
 	/** Validate the document array */
-	public validate(documentList: Document<TSchema, TSchemaDefinition>[]): Map<string, string[]> {
+	public validate(documentList: Document<TSchema>[]): Map<string, string[]> {
 		return documentList.reduce<Map<string, string[]>>((acc, document, index) => {
 			const documentErrors = document.validate();
 
@@ -84,7 +78,7 @@ class DocumentArrayType<
 
 	/** Create an array of foreign key definitions that will be validated before save */
 	public override transformForeignKeyDefinitionsToDb(
-		documentList: Document<TSchema, TSchemaDefinition>[],
+		documentList: Document<TSchema>[],
 	): ForeignKeyDbDefinition[] {
 		return documentList
 			.map((document) => {
@@ -98,7 +92,7 @@ class DocumentArrayType<
 	}
 
 	/** Generate subdocument instances */
-	private *makeSubDocument(record: MvRecord): Generator<Document<TSchema, TSchemaDefinition>> {
+	private *makeSubDocument(record: MvRecord): Generator<Document<TSchema>> {
 		const makeSubRecord = (iteration: number): MvRecord =>
 			this.valueSchema.getMvPaths().reduce<MvRecord>((acc, path) => {
 				const value = this.getFromMvArray(path.concat([iteration]), record);
@@ -114,7 +108,7 @@ class DocumentArrayType<
 			if (subRecord.length === 0) {
 				return;
 			}
-			const subdocument = Document.createSubdocumentFromRecord<TSchema, TSchemaDefinition>(
+			const subdocument = Document.createSubdocumentFromRecord<TSchema>(
 				this.valueSchema,
 				subRecord,
 			);

--- a/src/schemaType/EmbeddedType.ts
+++ b/src/schemaType/EmbeddedType.ts
@@ -6,10 +6,7 @@ import type { MvRecord } from '../types';
 import BaseSchemaType from './BaseSchemaType';
 
 /** Embedded Schema Type */
-class EmbeddedType<
-	TSchema extends Schema<TSchemaDefinition>,
-	TSchemaDefinition extends SchemaDefinition,
-> extends BaseSchemaType {
+class EmbeddedType<TSchema extends Schema<SchemaDefinition>> extends BaseSchemaType {
 	/** An instance of Schema representing the the document structure of embedded object contents */
 	private readonly valueSchema: TSchema;
 
@@ -23,7 +20,7 @@ class EmbeddedType<
 	 * Cast to embedded data type
 	 * @throws {@link TypeError} Throws if a non-null/non-object is passed
 	 */
-	public override cast(value: unknown): Document<TSchema, TSchemaDefinition> {
+	public override cast(value: unknown): Document<TSchema> {
 		// convert value to a plain structure and then recast as embedded document
 		const plainValue = value == null ? {} : JSON.parse(JSON.stringify(value));
 		if (!isPlainObject(plainValue)) {
@@ -33,8 +30,8 @@ class EmbeddedType<
 	}
 
 	/** Get value from mv data */
-	public get(record: MvRecord): Document<TSchema, TSchemaDefinition> {
-		const embeddedDocument = Document.createSubdocumentFromRecord<TSchema, TSchemaDefinition>(
+	public get(record: MvRecord): Document<TSchema> {
+		const embeddedDocument = Document.createSubdocumentFromRecord<TSchema>(
 			this.valueSchema,
 			record,
 		);
@@ -42,7 +39,7 @@ class EmbeddedType<
 	}
 
 	/** Set specified embedded document value into mv record */
-	public set(originalRecord: MvRecord, setValue: Document<TSchema, TSchemaDefinition>): MvRecord {
+	public set(originalRecord: MvRecord, setValue: Document<TSchema>): MvRecord {
 		const record = cloneDeep(originalRecord);
 		const subrecord = setValue.transformDocumentToRecord();
 		subrecord.forEach((value, arrayPos) => {
@@ -54,7 +51,7 @@ class EmbeddedType<
 	}
 
 	/** Validate the embedded document */
-	public validate(document: Document<TSchema, TSchemaDefinition>): Map<string, string[]> {
+	public validate(document: Document<TSchema>): Map<string, string[]> {
 		// - validation against the embedded document will return a single object with 0 to n keys - only those with keys indicate errors;
 		return document.validate();
 	}


### PR DESCRIPTION
While doing the work for #719, I learned that the `TSchemaDefinition` generics being used in several types/classes/etc. is actually not necessary. I think it was originally necessary in a lot of those scenarios but further refinements in the initial PR that utilized them made it ultimately unnecessary. When removing that generic from these places, the inference continues to work properly and the types are significantly easier to work with.

This PR eliminates all of those `TSchemaDefinition` generics that were in place except in the `Schema` class itself where the generic is used to obtain the definition supplied to the `Schema` constructor.