### PR TITLE
Include cause in MvisError, TimeoutError, and UnknownError

### DIFF
--- a/src/Connection.ts
+++ b/src/Connection.ts
@@ -482,26 +482,22 @@ class Connection {
 	private handleAxiosError(err: AxiosError): never {
 		if (err.code === 'ETIMEDOUT') {
 			this.logHandler.error(`Timeout error occurred in MVIS request: ${err.message}`);
-			throw new TimeoutError({ message: err.message });
+			throw new TimeoutError(err, { message: err.message });
 		}
 
 		this.logHandler.error(`Error occurred in MVIS request: ${err.message}`);
-		throw new MvisError({
-			message: err.message,
-			mvisRequest: err.request,
-			mvisResponse: err.response,
-		});
+		throw new MvisError(err, { message: err.message });
 	}
 
 	/** Handle an unknown error */
 	private handleUnexpectedError(err: unknown): never {
 		if (err instanceof Error) {
 			this.logHandler.error(`Error occurred in MVIS request: ${err.message}`);
-			throw new UnknownError({ message: err.message });
+			throw new UnknownError(err, { message: err.message });
 		}
 
 		this.logHandler.error('Unknown error occurred in MVIS request');
-		throw new UnknownError();
+		throw new UnknownError(err);
 	}
 }
 

--- a/src/__tests__/Connection.test.ts
+++ b/src/__tests__/Connection.test.ts
@@ -862,7 +862,7 @@ describe('executeDbSubroutine', () => {
 				},
 				{ requestId },
 			),
-		).rejects.toThrow(MvisError);
+		).rejects.toThrow(new MvisError(err, { message: err.message }));
 	});
 
 	test('should throw TimeoutError if axios call rejects with an AxiosError that is a timeout', async () => {
@@ -907,7 +907,7 @@ describe('executeDbSubroutine', () => {
 				},
 				{ requestId },
 			),
-		).rejects.toThrow(TimeoutError);
+		).rejects.toThrow(new TimeoutError(err, { message: err.message }));
 	});
 
 	test("should throw UnknownError with error's message if axios call rejects with an Error other than an AxiosError", async () => {
@@ -952,7 +952,7 @@ describe('executeDbSubroutine', () => {
 				},
 				{ requestId },
 			),
-		).rejects.toThrow(new UnknownError({ message: errMsg }));
+		).rejects.toThrow(new UnknownError(err, { message: errMsg }));
 	});
 
 	test('should throw UnknownError if axios call rejects with something other than an error', async () => {
@@ -996,7 +996,7 @@ describe('executeDbSubroutine', () => {
 				},
 				{ requestId },
 			),
-		).rejects.toThrow(UnknownError);
+		).rejects.toThrow(new UnknownError(errMsg));
 	});
 });
 

--- a/src/errors/MvisError.ts
+++ b/src/errors/MvisError.ts
@@ -1,29 +1,20 @@
+import type { AxiosError } from 'axios';
 import BaseError from './BaseError';
 
 interface MvisErrorConstructorOptions {
 	message?: string;
-	mvisRequest?: unknown;
-	mvisResponse?: unknown;
 }
 
 /** Error thrown when an error occurs when communicating with the connection manager */
 class MvisError extends BaseError {
-	/** Request object passed to connection manager */
-	public readonly mvisRequest: unknown;
-
-	/** Response object returned from connection manager (if any) */
-	public readonly mvisResponse: unknown;
-
-	public constructor({
-		message = 'Error in MVIS communication',
-		mvisRequest = {},
-		mvisResponse = {},
-	}: MvisErrorConstructorOptions = {}) {
+	public constructor(
+		cause: AxiosError,
+		{ message = 'Error in MVIS communication' }: MvisErrorConstructorOptions = {},
+	) {
 		const name = 'MvisError';
 		super(message, name);
 
-		this.mvisRequest = mvisRequest;
-		this.mvisResponse = mvisResponse;
+		this.cause = cause;
 	}
 }
 

--- a/src/errors/TimeoutError.ts
+++ b/src/errors/TimeoutError.ts
@@ -1,3 +1,4 @@
+import type { AxiosError } from 'axios';
 import BaseError from './BaseError';
 
 // #region Types
@@ -7,11 +8,14 @@ interface TimeoutErrorConstructorOptions {
 // #endregion
 
 class TimeoutError extends BaseError {
-	public constructor({
-		message = 'The request to the DB server timed out',
-	}: TimeoutErrorConstructorOptions = {}) {
+	public constructor(
+		cause: AxiosError,
+		{ message = 'The request to the DB server timed out' }: TimeoutErrorConstructorOptions = {},
+	) {
 		const name = 'TimeoutError';
 		super(message, name);
+
+		this.cause = cause;
 	}
 }
 

--- a/src/errors/UnknownError.ts
+++ b/src/errors/UnknownError.ts
@@ -7,11 +7,14 @@ interface UnknownErrorConstructorOptions {
 // #endregion
 
 class UnknownError extends BaseError {
-	public constructor({
-		message = 'An unknown error has occurred',
-	}: UnknownErrorConstructorOptions = {}) {
+	public constructor(
+		cause: unknown,
+		{ message = 'An unknown error has occurred' }: UnknownErrorConstructorOptions = {},
+	) {
 		const name = 'UnknownError';
 		super(message, name);
+
+		this.cause = cause;
 	}
 }
 

--- a/src/errors/__tests__/MvisError.test.ts
+++ b/src/errors/__tests__/MvisError.test.ts
@@ -1,36 +1,20 @@
+import { AxiosError } from 'axios';
 import MvisError from '../MvisError';
 
 test('should instantiate error with expected instance properties', (): void => {
-	const error = new MvisError();
+	const axiosError = new AxiosError();
+	const error = new MvisError(axiosError);
 	const expected = {
 		name: 'MvisError',
 		message: 'Error in MVIS communication',
-		mvisRequest: {},
-		mvisResponse: {},
+		cause: axiosError,
 	};
 	expect(error).toMatchObject(expected);
 });
 
 test('should allow for override of message', (): void => {
+	const axiosError = new AxiosError();
 	const message = 'foo';
-	const error = new MvisError({
-		message,
-	});
+	const error = new MvisError(axiosError, { message });
 	expect(error.message).toEqual(message);
-});
-
-test('should allow for override of mvisRequest', (): void => {
-	const mvisRequest = { foo: 'foo' };
-	const error = new MvisError({
-		mvisRequest,
-	});
-	expect(error.mvisRequest).toEqual(mvisRequest);
-});
-
-test('should allow for override of mvisResponse', (): void => {
-	const mvisResponse = { foo: 'foo' };
-	const error = new MvisError({
-		mvisResponse,
-	});
-	expect(error.mvisResponse).toEqual(mvisResponse);
 });

--- a/src/errors/__tests__/TimeoutError.test.ts
+++ b/src/errors/__tests__/TimeoutError.test.ts
@@ -1,18 +1,20 @@
+import { AxiosError } from 'axios';
 import TimeoutError from '../TimeoutError';
 
 test('should instantiate error with expected instance properties', () => {
-	const error = new TimeoutError();
+	const axiosError = new AxiosError();
+	const error = new TimeoutError(axiosError);
 	const expected = {
 		name: 'TimeoutError',
 		message: 'The request to the DB server timed out',
+		cause: axiosError,
 	};
 	expect(error).toMatchObject(expected);
 });
 
 test('should allow for override of message', () => {
+	const axiosError = new AxiosError();
 	const message = 'foo';
-	const error = new TimeoutError({
-		message,
-	});
+	const error = new TimeoutError(axiosError, { message });
 	expect(error.message).toEqual(message);
 });

--- a/src/errors/__tests__/UnknownError.test.ts
+++ b/src/errors/__tests__/UnknownError.test.ts
@@ -1,18 +1,19 @@
 import UnknownError from '../UnknownError';
 
 test('should instantiate error with expected instance properties', () => {
-	const error = new UnknownError();
+	const cause = new Error();
+	const error = new UnknownError(cause);
 	const expected = {
 		name: 'UnknownError',
 		message: 'An unknown error has occurred',
+		cause,
 	};
 	expect(error).toMatchObject(expected);
 });
 
 test('should allow for override of message', () => {
+	const cause = new Error();
 	const message = 'foo';
-	const error = new UnknownError({
-		message,
-	});
+	const error = new UnknownError(cause, { message });
 	expect(error.message).toEqual(message);
 });


### PR DESCRIPTION
As of Node 16.9+, the `cause` property is available on `Error` objects. This allows for an improvement with scenarios where an error is caught and thrown as a different type of error so that the original error can be included on the thrown `Error`.

This PR modifies the `MvisError`, `TimeoutError`, and `UnknownError` subclasses so that a `cause` parameter is required. The provided `cause` will be set as the `cause` property on the `Error` instance which will allow consumers to obtain the originating error.

For `MvisError` and `TimeoutError`, the `cause` will always be an `AxiosError`. For `UnknownError`, the `cause` is of type `unknown`.

As part of this change, the `mvisRequest` and `mvisResponse` properties have been removed from the `MvisError` instance as this information is available on the `cause` property.