### PR TITLE
Allow optional properties to be undefined on input for document and model in TS definitions

### DIFF
--- a/src/Document.ts
+++ b/src/Document.ts
@@ -3,12 +3,12 @@ import { TransformDataError } from './errors';
 import ForeignKeyDbTransformer from './ForeignKeyDbTransformer';
 import type Schema from './Schema';
 import type { InferDocumentObject } from './Schema';
-import type { DbServerDelimiters, MvRecord } from './types';
+import type { DbServerDelimiters, DeepOptionalNullable, MvRecord } from './types';
 
 // #region Types
 /** Type of data property for constructing a document dependent upon the schema */
 export type DocumentData<TSchema extends Schema | null> = TSchema extends Schema
-	? InferDocumentObject<TSchema>
+	? DeepOptionalNullable<InferDocumentObject<TSchema>>
 	: never;
 
 export interface DocumentConstructorOptions<TSchema extends Schema | null> {

--- a/src/Schema.ts
+++ b/src/Schema.ts
@@ -29,7 +29,14 @@ import type {
 	SchemaTypeDefinitionScalar,
 	SchemaTypeDefinitionString,
 } from './schemaType';
-import type { DataTransformer, DecryptFn, EncryptFn, FlattenObject, MarkRequired } from './types';
+import type {
+	DataTransformer,
+	DecryptFn,
+	EncryptFn,
+	FlattenObject,
+	MarkRequired,
+	Remap,
+} from './types';
 
 // #region Types
 export type SchemaTypeDefinition =
@@ -65,16 +72,18 @@ type PickAndMark<T extends SchemaTypeDefinitionScalar, K extends keyof T = never
 	'dictionary'
 >;
 
-export type DictionaryTypeDefinitionString = PickAndMark<SchemaTypeDefinitionString>;
-export type DictionaryTypeDefinitionNumber = PickAndMark<SchemaTypeDefinitionNumber>;
-export type DictionaryTypeDefinitionBoolean = PickAndMark<SchemaTypeDefinitionBoolean>;
-export type DictionaryTypeDefinitionISOCalendarDate =
-	PickAndMark<SchemaTypeDefinitionISOCalendarDate>;
-export type DictionaryTypeDefinitionISOCalendarDateTime = PickAndMark<
-	SchemaTypeDefinitionISOCalendarDateTime,
-	'dbFormat'
+export type DictionaryTypeDefinitionString = Remap<PickAndMark<SchemaTypeDefinitionString>>;
+export type DictionaryTypeDefinitionNumber = Remap<PickAndMark<SchemaTypeDefinitionNumber>>;
+export type DictionaryTypeDefinitionBoolean = Remap<PickAndMark<SchemaTypeDefinitionBoolean>>;
+export type DictionaryTypeDefinitionISOCalendarDate = Remap<
+	PickAndMark<SchemaTypeDefinitionISOCalendarDate>
 >;
-export type DictionaryTypeDefinitionISOTime = PickAndMark<SchemaTypeDefinitionISOTime, 'dbFormat'>;
+export type DictionaryTypeDefinitionISOCalendarDateTime = Remap<
+	PickAndMark<SchemaTypeDefinitionISOCalendarDateTime, 'dbFormat'>
+>;
+export type DictionaryTypeDefinitionISOTime = Remap<
+	PickAndMark<SchemaTypeDefinitionISOTime, 'dbFormat'>
+>;
 
 export type DictionaryTypeDefinition =
 	| DictionaryTypeDefinitionString
@@ -155,12 +164,12 @@ export type InferDocumentObject<TSchema extends Schema, TConstraint = SchemaType
 		: never;
 
 /** Infer the shape of a `Model` instance based upon the Schema it was instantiated with */
-export type InferModelObject<TSchema extends Schema> = {
-	_id: string;
-	__v: string;
-} & InferDocumentObject<TSchema> extends infer O
-	? { [K in keyof O]: O[K] }
-	: never;
+export type InferModelObject<TSchema extends Schema> = Remap<
+	{
+		_id: string;
+		__v: string;
+	} & InferDocumentObject<TSchema>
+>;
 
 /**
  * Flatten a document to string keyPath (i.e. { "foo.bar.baz": number })

--- a/src/Schema.ts
+++ b/src/Schema.ts
@@ -165,10 +165,7 @@ export type InferDocumentObject<TSchema extends Schema, TConstraint = SchemaType
 
 /** Infer the shape of a `Model` instance based upon the Schema it was instantiated with */
 export type InferModelObject<TSchema extends Schema> = Remap<
-	{
-		_id: string;
-		__v: string;
-	} & InferDocumentObject<TSchema>
+	{ _id: string; __v: string } & InferDocumentObject<TSchema>
 >;
 
 /**

--- a/src/__tests__/Document.test.ts
+++ b/src/__tests__/Document.test.ts
@@ -1,8 +1,12 @@
 import mockDelimiters from '#test/mockDelimiters';
-import type { BuildForeignKeyDefinitionsResult, DocumentConstructorOptions } from '../Document';
+import type {
+	BuildForeignKeyDefinitionsResult,
+	DocumentConstructorOptions,
+	DocumentData,
+} from '../Document';
 import Document from '../Document';
 import { TransformDataError } from '../errors';
-import type { SchemaDefinition } from '../Schema';
+import type { ISOCalendarDate, ISOCalendarDateTime, ISOTime, SchemaDefinition } from '../Schema';
 import Schema from '../Schema';
 import type { Equals, MvRecord } from '../types';
 
@@ -1023,5 +1027,111 @@ describe('type inference', () => {
 		// any other property should be unknown
 		const test4: Equals<DocumentResult['otherProp'], unknown> = true;
 		expect(test4).toBe(true);
+	});
+});
+
+describe('utility types', () => {
+	describe('DocumentData', () => {
+		test('should convert optional schema properties to have optional modifier', () => {
+			const schema = new Schema({
+				boolean: { type: 'boolean', path: 1 },
+				string: { type: 'string', path: 2 },
+				number: { type: 'number', path: 3 },
+				isoCalendarDate: { type: 'ISOCalendarDate', path: 4 },
+				isoTime: { type: 'ISOTime', path: 5 },
+				isoCalendarDateTime: { type: 'ISOCalendarDateTime', path: 6 },
+			});
+
+			const test1: Equals<
+				DocumentData<typeof schema>,
+				{
+					boolean?: boolean | null;
+					string?: string | null;
+					number?: number | null;
+					isoCalendarDate?: ISOCalendarDate | null;
+					isoTime?: ISOTime | null;
+					isoCalendarDateTime?: ISOCalendarDateTime | null;
+				}
+			> = true;
+			expect(test1).toBe(true);
+		});
+
+		test('should convert optional schema properties to have optional modifier in deep schemas', () => {
+			const schema = new Schema({
+				booleanOptional: { type: 'boolean', path: '1' },
+				booleanRequired: { type: 'boolean', path: '2', required: true },
+				stringOptional: { type: 'string', path: '3' },
+				stringRequired: { type: 'string', path: '4', required: true },
+				numberOptional: { type: 'number', path: '5' },
+				numberRequired: { type: 'number', path: '6', required: true },
+				isoCalendarDateOptional: { type: 'ISOCalendarDate', path: '7' },
+				isoCalendarDateRequired: { type: 'ISOCalendarDate', path: '8', required: true },
+				isoTimeOptional: { type: 'ISOTime', path: '9' },
+				isoTimeRequired: { type: 'ISOTime', path: '10', required: true },
+				isoCalendarDateTimeOptional: { type: 'ISOCalendarDateTime', path: '11' },
+				isoCalendarDateTimeRequired: { type: 'ISOCalendarDateTime', path: '12', required: true },
+				arrayOptional: [{ type: 'string', path: '13' }],
+				arrayRequired: [{ type: 'string', path: '14', required: true }],
+				nestedArrayOptional: [[{ type: 'string', path: '15' }]],
+				nestedArrayRequired: [[{ type: 'string', path: '16', required: true }]],
+				embeddedOptional: new Schema({
+					innerEmbeddedProp: { type: 'string', path: '17' },
+				}),
+				embeddedRequired: new Schema({
+					innerEmbeddedProp: { type: 'string', path: '18', required: true },
+				}),
+				documentArrayOptional: [
+					{
+						docStringProp: { type: 'string', path: '19' },
+						docNumberProp: { type: 'number', path: '20' },
+					},
+				],
+				documentArrayRequired: [
+					{
+						docStringProp: { type: 'string', path: '21', required: true },
+						docNumberProp: { type: 'number', path: '22' },
+					},
+				],
+				documentArraySchemaOptional: [
+					new Schema({
+						docStringProp: { type: 'string', path: '23' },
+					}),
+				],
+				documentArraySchemaRequired: [
+					new Schema({
+						docStringProp: { type: 'string', path: '24', required: true },
+					}),
+				],
+			});
+
+			const test1: Equals<
+				DocumentData<typeof schema>,
+				{
+					booleanOptional?: boolean | null;
+					booleanRequired: boolean;
+					stringOptional?: string | null;
+					stringRequired: string;
+					numberOptional?: number | null;
+					numberRequired: number;
+					isoCalendarDateOptional?: ISOCalendarDate | null;
+					isoCalendarDateRequired: ISOCalendarDate;
+					isoTimeOptional?: ISOTime | null;
+					isoTimeRequired: ISOTime;
+					isoCalendarDateTimeOptional?: ISOCalendarDateTime | null;
+					isoCalendarDateTimeRequired: ISOCalendarDateTime;
+					arrayOptional: (string | null)[];
+					arrayRequired: string[];
+					nestedArrayOptional: (string | null)[][];
+					nestedArrayRequired: string[][];
+					embeddedOptional: { innerEmbeddedProp?: string | null };
+					embeddedRequired: { innerEmbeddedProp: string };
+					documentArrayOptional: { docStringProp?: string | null; docNumberProp?: number | null }[];
+					documentArrayRequired: { docStringProp: string; docNumberProp?: number | null }[];
+					documentArraySchemaOptional: { docStringProp?: string | null }[];
+					documentArraySchemaRequired: { docStringProp: string }[];
+				}
+			> = true;
+			expect(test1).toBe(true);
+		});
 	});
 });

--- a/src/__tests__/compileModel.test.ts
+++ b/src/__tests__/compileModel.test.ts
@@ -671,7 +671,7 @@ describe('save', () => {
 
 		const id = 'id';
 		// @ts-expect-error: intentionally invalid data to trigger validation failure
-		const model = new Model({ _id: id, data: { prop1: 'prop1-value' } });
+		const model = new Model({ _id: id, data: { prop1: 1337 } });
 		model.validate = () => new Map([['prop1', ['Not good']]]);
 
 		await expect(model.save()).rejects.toThrow(DataValidationError);

--- a/src/types/Utility.ts
+++ b/src/types/Utility.ts
@@ -30,3 +30,22 @@ export type FromPaths<T extends { path: string; type: unknown }> = {
 
 /** Flatten an object to string keyPath (i.e. { "foo.bar.baz": number }) */
 export type FlattenObject<TObject extends Record<string, unknown>> = FromPaths<ToPaths<TObject>>;
+
+/** Make composite types user friendly in the editor by constructing a new type with object keys */
+export type Remap<T> = T extends infer O ? { [Key in keyof O]: O[Key] } : never;
+
+/** Deeply mark all nullable properties as optional */
+export type DeepOptionalNullable<TObject> = Remap<
+	{
+		[Key in keyof TObject as null extends TObject[Key] ? Key : never]?: TObject[Key];
+	} & {
+		[Key in keyof TObject as null extends TObject[Key] ? never : Key]: TObject[Key] extends Record<
+			string,
+			unknown
+		>
+			? DeepOptionalNullable<TObject[Key]>
+			: TObject[Key] extends (infer U extends Record<string, unknown>)[]
+				? DeepOptionalNullable<U>[]
+				: TObject[Key];
+	}
+>;


### PR DESCRIPTION
When outputting a property defined as optional in a schema, MVOM will always set that property's value to `null`. The `InferDocumentObject` and `InferModelObject` utility types correspondingly indicate these properties as having a type unioned with `null`.

The `InferDocumentObject` type was used in the `DocumentData` type which is used for the input objects for `Document` and `Model` instances. However, MVOM does not distinguish between `null` and `undefined` on input. That is, you do not have to specify an optional property in the input object. However, the use of the output type `InferDocumentObject` was forcing specification of optional properties as `null` and did not allow `undefined`. This PR modifies the `DocumentData` type to leverage a new utility type named `DeepOptionalNullable`. This utility type will recurse through an object type and make any properties that are nullable also optional. This change allows for providing `undefined` for optional properties for the input data objects when constructing `Model` or `Document` instances.

Additionally, this PR introduces a new `Remap` utility type which will make intersection type definitions easier to read by remapping them into a single object type instead of the intersection type. This was utilized in the `DeepOptionalNullable` type and was also applied to a few existing types in the `Schema` module.