### PR TITLE
Add RecordNotFoundError

### DIFF
--- a/src/constants/dbErrors.ts
+++ b/src/constants/dbErrors.ts
@@ -30,7 +30,7 @@ const dbErrors: Record<string, DbError> = {
 	},
 	recordWriteUnknown: { code: 19, message: 'Unknown error writing database record' },
 	maxPayloadExceeded: { code: 20, message: 'Maximum return payload size exceeded' },
-	recordNotFoundError: { code: 21, message: 'Database record not found' },
+	recordNotFound: { code: 21, message: 'Database record not found' },
 };
 
 export default dbErrors;

--- a/src/constants/dbErrors.ts
+++ b/src/constants/dbErrors.ts
@@ -30,6 +30,7 @@ const dbErrors: Record<string, DbError> = {
 	},
 	recordWriteUnknown: { code: 19, message: 'Unknown error writing database record' },
 	maxPayloadExceeded: { code: 20, message: 'Maximum return payload size exceeded' },
+	recordNotFoundError: { code: 21, message: 'Database record not found' },
 };
 
 export default dbErrors;

--- a/src/errors/RecordNotFoundError.ts
+++ b/src/errors/RecordNotFoundError.ts
@@ -1,0 +1,27 @@
+import BaseError from './BaseError';
+
+interface RecordNotFoundErrorConstructorOptions {
+	message?: string;
+	filename: string;
+	recordId: string;
+}
+
+/** Error thrown when an error occurs due to a record not being found */
+class RecordNotFoundError extends BaseError {
+	public readonly filename: string;
+
+	public readonly recordId: string;
+
+	public constructor({
+		message = 'Database record not found',
+		filename,
+		recordId,
+	}: RecordNotFoundErrorConstructorOptions) {
+		const name = 'RecordNotFoundError';
+		super(message, name);
+		this.filename = filename;
+		this.recordId = recordId;
+	}
+}
+
+export default RecordNotFoundError;

--- a/src/errors/RecordNotFoundError.ts
+++ b/src/errors/RecordNotFoundError.ts
@@ -19,6 +19,7 @@ class RecordNotFoundError extends BaseError {
 	}: RecordNotFoundErrorConstructorOptions) {
 		const name = 'RecordNotFoundError';
 		super(message, name);
+
 		this.filename = filename;
 		this.recordId = recordId;
 	}

--- a/src/errors/__tests__/RecordNotFoundError.test.ts
+++ b/src/errors/__tests__/RecordNotFoundError.test.ts
@@ -1,0 +1,25 @@
+import RecordNotFoundError from '../RecordNotFoundError';
+
+const filename = 'filename';
+const recordId = 'recordId';
+
+test('should instantiate error with expected instance properties', (): void => {
+	const error = new RecordNotFoundError({ filename, recordId });
+	const expected = {
+		name: 'RecordNotFoundError',
+		message: 'Database record not found',
+		filename,
+		recordId,
+	};
+	expect(error).toMatchObject(expected);
+});
+
+test('should allow for override of message', (): void => {
+	const message = 'foo';
+	const error = new RecordNotFoundError({
+		message,
+		filename,
+		recordId,
+	});
+	expect(error.message).toEqual(message);
+});

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -7,6 +7,7 @@ export { default as InvalidServerFeaturesError } from './InvalidServerFeaturesEr
 export { default as MvisError } from './MvisError';
 export { default as QueryLimitError } from './QueryLimitError';
 export { default as RecordLockedError } from './RecordLockedError';
+export { default as RecordNotFoundError } from './RecordNotFoundError';
 export { default as RecordVersionError } from './RecordVersionError';
 export { default as TimeoutError } from './TimeoutError';
 export { default as TransformDataError } from './TransformDataError';

--- a/src/unibasicTemplates/constants/error.njk
+++ b/src/unibasicTemplates/constants/error.njk
@@ -19,3 +19,4 @@ equ ERROR_DIGEST_HASH to {{dbErrors.digestHash.code}}
 equ ERROR_FOREIGN_KEY to {{dbErrors.foreignKeyValidation.code}}
 equ ERROR_ENCODE_FILE to {{dbErrors.fileEncodeBase64.code}}
 equ ERROR_MAX_PAYLOAD_EXCEEDED to {{dbErrors.maxPayloadExceeded.code}}
+equ ERROR_RECORD_NOT_FOUND to {{dbErrors.recordNotFound.code}}


### PR DESCRIPTION
### Summary

This PR maps the new `RecordNotFoundError` within MVOM. This error is currently not in use, but will be in upcoming PRs to support the new increment operation.

The new error was added in:

- the `dbErrors` object in `constants/dbErrors.ts`
- the equates record in `unibasicTemplates/constants/error.njk`
- a new `RecordNotFoundError` class in `errors/RecordNotFoundError`