### PR TITLE
Add additional type exports from main

### DIFF
--- a/src/Document.ts
+++ b/src/Document.ts
@@ -27,7 +27,7 @@ export interface BuildForeignKeyDefinitionsResult {
  * An intersection type that combines the `Document` class instance with the
  * inferred shape of the document object based on the schema definition.
  */
-type DocumentCompositeValue<TSchema extends Schema | null> = TSchema extends Schema
+export type DocumentCompositeValue<TSchema extends Schema | null> = TSchema extends Schema
 	? Document<TSchema> & InferDocumentObject<TSchema>
 	: Document<TSchema>;
 // #endregion

--- a/src/compileModel.ts
+++ b/src/compileModel.ts
@@ -21,11 +21,13 @@ export type ModelConstructor<TSchema extends Schema | null> = ReturnType<
 	typeof compileModel<TSchema>
 >;
 
+export type Model<TSchema extends Schema | null> = InstanceType<ModelConstructor<TSchema>>;
+
 /**
  * An intersection type that combines the `Model` class instance with the
  * inferred shape of the model object based on the schema definition.
  */
-type ModelCompositeValue<TSchema extends Schema | null> = TSchema extends Schema
+export type ModelCompositeValue<TSchema extends Schema | null> = TSchema extends Schema
 	? InstanceType<ModelConstructor<TSchema>> & InferModelObject<TSchema>
 	: InstanceType<ModelConstructor<TSchema>>;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,14 @@
 export { default as Connection } from './Connection';
-export { default as Document } from './Document';
+export {
+	default as Document,
+	type DocumentData,
+	type DocumentConstructorOptions,
+	type DocumentCompositeValue,
+} from './Document';
 export {
 	default as Schema,
 	type SchemaDefinition,
+	type DictionariesOption,
 	type SchemaConstructorOptions,
 	type ISOCalendarDate,
 	type ISOCalendarDateTime,
@@ -12,7 +18,12 @@ export {
 	type InferModelObject,
 	type InferSchemaPaths,
 } from './Schema';
-export type { ModelConstructor } from './compileModel';
+export type {
+	ModelConstructor,
+	ModelConstructorOptions,
+	Model,
+	ModelCompositeValue,
+} from './compileModel';
 export {
 	MvisError,
 	DataValidationError,


### PR DESCRIPTION
This PR makes two changes:
1. Creates a new type named `Model` which is the `InstanceType` of the `ModelConstructor`.
2. Export several types our of the main entry point for consumer use.

The following additional types are now exported from the main entry point:
* `DocumentData`
* `DocumentConstructorOptions`
* `DocumentCompositeValue`
* `DictionariesOption`
* `ModelConstructorOptions`
* `Model`
* `ModelCompositeValue`