### PR TITLE
Split query filter types into smaller parts and export query types

### DIFF
--- a/src/Query.ts
+++ b/src/Query.ts
@@ -96,14 +96,20 @@ type FlattenedDocumentDictionaries<TSchema extends Schema> = FlattenDocument<
 	Exclude<SchemaTypeDefinition, SchemaTypeDefinitionScalar> | { dictionary: string }
 >;
 
+export type SchemaFilter<TSchema extends Schema | null> = (TSchema extends Schema<
+	SchemaDefinition,
+	infer TDictionariesOption
+>
+	? FlattenedDocumentDictionaries<TSchema> &
+			InferDictionariesType<TDictionariesOption> extends infer O
+		? { [Key in keyof O]?: Condition<NonNullable<O[Key]>> }
+		: never
+	: Record<never, never>) & { _id?: Condition<string> };
+export type SchemaFilterKeys<TSchema extends Schema | null> = keyof SchemaFilter<TSchema>;
+
 /** Query Filter */
 export type Filter<TSchema extends Schema | null> = RootFilterOperators<TSchema> &
-	((TSchema extends Schema<SchemaDefinition, infer TDictionariesOption>
-		? FlattenedDocumentDictionaries<TSchema> &
-				InferDictionariesType<TDictionariesOption> extends infer O
-			? { [Key in keyof O]?: Condition<NonNullable<O[Key]>> }
-			: never
-		: Record<never, never>) & { _id?: Condition<string> });
+	SchemaFilter<TSchema>;
 
 /** Sort criteria */
 export type SortCriteria<TSchema extends Schema | null> = [

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,13 @@ export {
 	type DocumentConstructorOptions,
 	type DocumentCompositeValue,
 } from './Document';
+export type {
+	SchemaFilter,
+	SchemaFilterKeys,
+	Filter,
+	QueryConstructorOptions,
+	SortCriteria,
+} from './Query';
 export {
 	default as Schema,
 	type SchemaDefinition,


### PR DESCRIPTION
This PR creates new types in the `Query` module named `SchemaFilter` and `SchemaFilterKeys`. The `SchemaFilter` type has been split from a portion of the `Filter` type which now leverages that type as part of its construction.

The main entry index now exports additional types:
* `SchemaFilter`
* `SchemaFilterKeys`
* `Filter`
* `QueryConstructorOptions`
* `SortCriteria`