### PR TITLE
Make SchemaFilterKeys only include strings and use in SortCriteria type

### DIFF
--- a/src/Query.ts
+++ b/src/Query.ts
@@ -105,17 +105,17 @@ export type SchemaFilter<TSchema extends Schema | null> = (TSchema extends Schem
 		? { [Key in keyof O]?: Condition<NonNullable<O[Key]>> }
 		: never
 	: Record<never, never>) & { _id?: Condition<string> };
-export type SchemaFilterKeys<TSchema extends Schema | null> = keyof SchemaFilter<TSchema>;
+export type SchemaFilterKeys<TSchema extends Schema | null> = Extract<
+	keyof SchemaFilter<TSchema>,
+	string
+>;
 
 /** Query Filter */
 export type Filter<TSchema extends Schema | null> = RootFilterOperators<TSchema> &
 	SchemaFilter<TSchema>;
 
 /** Sort criteria */
-export type SortCriteria<TSchema extends Schema | null> = [
-	Extract<Exclude<keyof Filter<TSchema>, keyof RootFilterOperators<TSchema>>, string>,
-	-1 | 1,
-][];
+export type SortCriteria<TSchema extends Schema | null> = [SchemaFilterKeys<TSchema>, -1 | 1][];
 
 export type QueryExecutionOptions = DbSubroutineSetupOptions;
 export interface QueryExecutionResult {


### PR DESCRIPTION
This PR adjusts the `SchemaFilterKeys` type to only include strings (i.e. excluding number or symbol) and reuses that type in the `SortCriteria` type, which was itself calculating the keys which could be used from the `Filter` type.