### PR TITLE
Prepare for version 3.0.0-rc.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.0-rc.3]
+
+- Adjust `SchemaFilterKeys` type to exclude non-string keys and use `SchemaFilterKeys` in construction of `SortCriteria` type ([#747](https://github.com/STORIS/mvom/pull/747))
+
+### TypeScript
+
 ## [3.0.0-rc.2]
 
 ### TypeScript
@@ -474,7 +480,8 @@ We've graduated from Alpha to Beta! Semver has been updated so breaking vs. non-
 
 Initial alpha release of this library! Thanks for using it!
 
-[unreleased]: https://github.com/storis/mvom/compare/3.0.0-rc.2...HEAD
+[unreleased]: https://github.com/storis/mvom/compare/3.0.0-rc.3...HEAD
+[3.0.0-rc.3]: https://github.com/storis/mvom/compare/3.0.0-rc.2...3.0.0-rc.3
 [3.0.0-rc.2]: https://github.com/storis/mvom/compare/3.0.0-rc.1...3.0.0-rc.2
 [3.0.0-rc.1]: https://github.com/storis/mvom/compare/3.0.0-rc.0...3.0.0-rc.1
 [3.0.0-rc.0]: https://github.com/storis/mvom/compare/2.0.0-rc.1...3.0.0-rc.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mvom",
-  "version": "3.0.0-rc.2",
+  "version": "3.0.0-rc.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mvom",
-      "version": "3.0.0-rc.2",
+      "version": "3.0.0-rc.3",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.25.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mvom",
   "private": true,
-  "version": "3.0.0-rc.2",
+  "version": "3.0.0-rc.3",
   "description": "Multivalue Object Mapper",
   "main": "index.js",
   "engines": {

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -40,7 +40,7 @@ const config: Config = {
 					lastVersion: 'current',
 					versions: {
 						current: {
-							label: '3.0.0-rc.2',
+							label: '3.0.0-rc.3',
 						},
 					},
 					remarkPlugins: [[npm2YarnPlugin, { sync: true }]],
@@ -70,7 +70,7 @@ const config: Config = {
 				},
 				{
 					type: 'docsVersion',
-					label: '3.0.0-rc.2',
+					label: '3.0.0-rc.3',
 					position: 'right',
 				},
 				{


### PR DESCRIPTION
This PR makes the necessary changes to release a new version `3.0.0-rc.3`. Included are updates to the following:
- `package.json` and `package-lock.json` versions
- Updates to CHANGELOG describing changes in this release
- Updates to documentation versions