### PR TITLE
Mvom increment

### DIFF
--- a/src/Schema.ts
+++ b/src/Schema.ts
@@ -180,7 +180,10 @@ export type FlattenDocument<TSchema extends Schema, TConstraint = SchemaTypeDefi
 		: never;
 
 /** Infer the string keyPaths of a schema */
-export type InferSchemaPaths<TSchema extends Schema> = keyof FlattenDocument<TSchema>;
+export type InferSchemaPaths<TSchema extends Schema> = Extract<
+	keyof FlattenDocument<TSchema>,
+	string
+>;
 // #endregion
 
 /** Schema constructor */
@@ -283,7 +286,7 @@ class Schema<
 	 * @throws {Error} Invalid path provided
 	 */
 	public transformPathToOrdinalPosition(
-		path: Extract<InferSchemaPaths<Schema<TSchemaDefinition, TDictionaries>>, string>,
+		path: InferSchemaPaths<Schema<TSchemaDefinition, TDictionaries>>,
 	): `${number}.${number}.${number}` {
 		const positionPaths = this.getPositionPaths();
 

--- a/src/Schema.ts
+++ b/src/Schema.ts
@@ -278,6 +278,61 @@ class Schema<
 		return [...positions];
 	}
 
+	/** Transform the paths to ordinal positions. Returning a '.' delimited string. Ex. "1.2.3"  */
+	public transformPathsToOrdinalPositions(paths: string[]): string[] {
+		if (paths.length === 0) {
+			return [];
+		}
+
+		const positionPaths = this.getPositionPaths();
+		const positionKeys = Array.from(positionPaths.keys());
+
+		const positions = paths.reduce((acc, positionPath) => {
+			if (positionPaths.has(positionPath)) {
+				// find the key in position paths
+				// add position
+				const ordinalPath =
+					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+					positionPaths.get(positionPath)!;
+				acc.add(this.buildOrdinalPathString(ordinalPath));
+			} else if (!positionPath.includes('.')) {
+				// if the property is a parent key, we will add positions for all children
+				// e.g we only pass property "name" to return all data for name.first, name.last, etc.
+				const matchedPositionPaths = positionKeys.filter(
+					(key) => key.split('.')[0] === positionPath,
+				);
+				matchedPositionPaths.forEach((key) => {
+					// add child position
+					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+					const ordinalPath = positionPaths.get(key)!;
+					acc.add(this.buildOrdinalPathString(ordinalPath));
+				});
+			}
+			return acc;
+		}, new Set<string>());
+
+		return [...positions];
+	}
+
+	private buildOrdinalPathString(ordinalPath: number[]): string {
+		if (ordinalPath.length === 0) {
+			return '';
+		}
+
+		const [attributePosition, valuePosition, subvaluePosition] = ordinalPath;
+		if (ordinalPath.length === 1) {
+			return `${attributePosition + 1}`;
+		}
+		if (ordinalPath.length === 2) {
+			return `${attributePosition + 1}.${valuePosition + 1}`;
+		}
+		if (ordinalPath.length === 3) {
+			return `${attributePosition + 1}.${valuePosition + 1}.${subvaluePosition + 1}`;
+		}
+
+		return '';
+	}
+
 	/** Build the dictionary path map for additional dictionaries provided as schema options */
 	private buildDictionaryPaths(
 		dictionaries: DictionariesOption = {},

--- a/src/Schema.ts
+++ b/src/Schema.ts
@@ -279,35 +279,23 @@ class Schema<
 	}
 
 	/**
-	 * Transform the paths to ordinal positions. Returning a '.' delimited string. Ex. "1.2.3"
-	 * @throws {Error} No paths provided
+	 * Transform the path to its ordinal position. Returning a '.' delimited string. Ex. "1.2.3"
 	 * @throws {Error} Invalid path provided
 	 */
-	public transformPathsToOrdinalPositions(
-		paths: Extract<InferSchemaPaths<Schema<TSchemaDefinition, TDictionaries>>, string>[],
-	): `${number}.${number}.${number}`[] {
-		if (paths.length === 0) {
-			throw new Error('No paths provided');
-		}
-
+	public transformPathToOrdinalPosition(
+		path: Extract<InferSchemaPaths<Schema<TSchemaDefinition, TDictionaries>>, string>,
+	): `${number}.${number}.${number}` {
 		const positionPaths = this.getPositionPaths();
 
-		const positions = paths.reduce((acc, positionPath) => {
-			if (positionPaths.has(positionPath)) {
-				// find the key in position paths
-				// add position
-				const ordinalPath =
-					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-					positionPaths.get(positionPath)!;
-				const [attributePosition, valuePosition = 0, subvaluePosition = 0] = ordinalPath;
-				acc.add(`${attributePosition + 1}.${valuePosition + 1}.${subvaluePosition + 1}`);
-			} else {
-				throw new Error('Invalid path provided');
-			}
-			return acc;
-		}, new Set<`${number}.${number}.${number}`>());
+		if (!positionPaths.has(path)) {
+			throw new Error('Invalid path provided');
+		}
 
-		return [...positions];
+		const ordinalPath =
+			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+			positionPaths.get(path)!;
+		const [attributePosition, valuePosition = 0, subvaluePosition = 0] = ordinalPath;
+		return `${attributePosition + 1}.${valuePosition + 1}.${subvaluePosition + 1}`;
 	}
 
 	/** Build the dictionary path map for additional dictionaries provided as schema options */

--- a/src/Schema.ts
+++ b/src/Schema.ts
@@ -278,14 +278,19 @@ class Schema<
 		return [...positions];
 	}
 
-	/** Transform the paths to ordinal positions. Returning a '.' delimited string. Ex. "1.2.3"  */
-	public transformPathsToOrdinalPositions(paths: string[]): string[] {
+	/**
+	 * Transform the paths to ordinal positions. Returning a '.' delimited string. Ex. "1.2.3"
+	 * @throws {Error} No paths provided
+	 * @throws {Error} Invalid path provided
+	 */
+	public transformPathsToOrdinalPositions(
+		paths: Extract<InferSchemaPaths<Schema<TSchemaDefinition, TDictionaries>>, string>[],
+	): `${number}.${number}.${number}`[] {
 		if (paths.length === 0) {
-			return [];
+			throw new Error('No paths provided');
 		}
 
 		const positionPaths = this.getPositionPaths();
-		const positionKeys = Array.from(positionPaths.keys());
 
 		const positions = paths.reduce((acc, positionPath) => {
 			if (positionPaths.has(positionPath)) {
@@ -294,43 +299,15 @@ class Schema<
 				const ordinalPath =
 					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 					positionPaths.get(positionPath)!;
-				acc.add(this.buildOrdinalPathString(ordinalPath));
-			} else if (!positionPath.includes('.')) {
-				// if the property is a parent key, we will add positions for all children
-				// e.g we only pass property "name" to return all data for name.first, name.last, etc.
-				const matchedPositionPaths = positionKeys.filter(
-					(key) => key.split('.')[0] === positionPath,
-				);
-				matchedPositionPaths.forEach((key) => {
-					// add child position
-					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-					const ordinalPath = positionPaths.get(key)!;
-					acc.add(this.buildOrdinalPathString(ordinalPath));
-				});
+				const [attributePosition, valuePosition = 0, subvaluePosition = 0] = ordinalPath;
+				acc.add(`${attributePosition + 1}.${valuePosition + 1}.${subvaluePosition + 1}`);
+			} else {
+				throw new Error('Invalid path provided');
 			}
 			return acc;
-		}, new Set<string>());
+		}, new Set<`${number}.${number}.${number}`>());
 
 		return [...positions];
-	}
-
-	private buildOrdinalPathString(ordinalPath: number[]): string {
-		if (ordinalPath.length === 0) {
-			return '';
-		}
-
-		const [attributePosition, valuePosition, subvaluePosition] = ordinalPath;
-		if (ordinalPath.length === 1) {
-			return `${attributePosition + 1}`;
-		}
-		if (ordinalPath.length === 2) {
-			return `${attributePosition + 1}.${valuePosition + 1}`;
-		}
-		if (ordinalPath.length === 3) {
-			return `${attributePosition + 1}.${valuePosition + 1}.${subvaluePosition + 1}`;
-		}
-
-		return '';
 	}
 
 	/** Build the dictionary path map for additional dictionaries provided as schema options */

--- a/src/Schema.ts
+++ b/src/Schema.ts
@@ -287,13 +287,11 @@ class Schema<
 	): `${number}.${number}.${number}` {
 		const positionPaths = this.getPositionPaths();
 
-		if (!positionPaths.has(path)) {
+		const ordinalPath = positionPaths.get(path);
+		if (ordinalPath == null) {
 			throw new Error('Invalid path provided');
 		}
 
-		const ordinalPath =
-			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-			positionPaths.get(path)!;
 		const [attributePosition, valuePosition = 0, subvaluePosition = 0] = ordinalPath;
 		return `${attributePosition + 1}.${valuePosition + 1}.${subvaluePosition + 1}`;
 	}

--- a/src/__tests__/Schema.test.ts
+++ b/src/__tests__/Schema.test.ts
@@ -389,14 +389,14 @@ describe('transformPathsToDbPositions', () => {
 });
 
 describe('transformPathsToOrdinalPositions', () => {
-	const embeddedDefinition: SchemaDefinition = {
+	const embeddedDefinition = {
 		innerEmbeddedProp: { type: 'string', path: '9' },
-	};
-	const documentArrayDefinition: SchemaDefinition = {
+	} satisfies SchemaDefinition;
+	const documentArrayDefinition = {
 		docStringProp: { type: 'string', path: '12' },
 		docNumberProp: { type: 'number', path: '13' },
-	};
-	const definition: SchemaDefinition = {
+	} satisfies SchemaDefinition;
+	const definition = {
 		stringProp: { type: 'string', path: '1' },
 		stringValueProp: { type: 'string', path: '14.2' },
 		stringSubvalueProp: { type: 'string', path: '14.2.3' },
@@ -416,50 +416,38 @@ describe('transformPathsToOrdinalPositions', () => {
 			},
 		],
 		documentArraySchemaProp: [new Schema(documentArrayDefinition)],
-	};
+	} satisfies SchemaDefinition;
 	const schema = new Schema(definition);
 
-	test('should return no positions if path list is empty', () => {
-		expect(schema.transformPathsToOrdinalPositions([])).toEqual([]);
+	test('should throw error if path list is empty', () => {
+		expect(() => schema.transformPathsToOrdinalPositions([])).toThrow(Error);
 	});
 
-	test('should return positions of specified path', () => {
-		expect(schema.transformPathsToOrdinalPositions(['stringProp'])).toEqual(['1']);
+	test('should return position of specified path filling in value and subvalue positions to 1 if not specified', () => {
+		expect(schema.transformPathsToOrdinalPositions(['stringProp'])).toEqual(['1.1.1']);
 	});
 
 	test('should return positions of multiple paths', () => {
 		expect(schema.transformPathsToOrdinalPositions(['stringProp', 'booleanProp'])).toEqual([
-			'1',
-			'3',
+			'1.1.1',
+			'3.1.1',
 		]);
-	});
-
-	test('should return positions of embedded documents', () => {
-		expect(schema.transformPathsToOrdinalPositions(['embeddedProp'])).toEqual(['9']);
 	});
 
 	test('should return positions of embedded document properties', () => {
 		expect(schema.transformPathsToOrdinalPositions(['embeddedProp.innerEmbeddedProp'])).toEqual([
-			'9',
+			'9.1.1',
 		]);
-	});
-
-	test('should return positions of document arrays', () => {
-		expect(schema.transformPathsToOrdinalPositions(['documentArrayProp'])).toEqual(['10', '11']);
 	});
 
 	test('should return positions of document array properties', () => {
 		expect(schema.transformPathsToOrdinalPositions(['documentArrayProp.docStringProp'])).toEqual([
-			'10',
+			'10.1.1',
 		]);
 	});
 
-	test('should return no positions if dotted path is not in schema', () => {
-		expect(schema.transformPathsToOrdinalPositions(['not.here'])).toEqual([]);
-	});
-
 	test('should return correct ordinal position if path is to a value', () => {
-		expect(schema.transformPathsToOrdinalPositions(['stringValueProp'])).toEqual(['14.2']);
+		expect(schema.transformPathsToOrdinalPositions(['stringValueProp'])).toEqual(['14.2.1']);
 	});
 
 	test('should return correct ordinal position if path is to a subvalue', () => {
@@ -467,7 +455,7 @@ describe('transformPathsToOrdinalPositions', () => {
 	});
 
 	test('should return correct ordinal position for array at value position', () => {
-		expect(schema.transformPathsToOrdinalPositions(['stringArrayValueProp'])).toEqual(['15.2']);
+		expect(schema.transformPathsToOrdinalPositions(['stringArrayValueProp'])).toEqual(['15.2.1']);
 	});
 });
 

--- a/src/__tests__/Schema.test.ts
+++ b/src/__tests__/Schema.test.ts
@@ -420,42 +420,32 @@ describe('transformPathsToOrdinalPositions', () => {
 	const schema = new Schema(definition);
 
 	test('should throw error if path list is empty', () => {
-		expect(() => schema.transformPathsToOrdinalPositions([])).toThrow(Error);
+		// @ts-expect-error: intentionally passing invalid argument to test
+		expect(() => schema.transformPathToOrdinalPosition('bad-path')).toThrow(Error);
 	});
 
 	test('should return position of specified path filling in value and subvalue positions to 1 if not specified', () => {
-		expect(schema.transformPathsToOrdinalPositions(['stringProp'])).toEqual(['1.1.1']);
-	});
-
-	test('should return positions of multiple paths', () => {
-		expect(schema.transformPathsToOrdinalPositions(['stringProp', 'booleanProp'])).toEqual([
-			'1.1.1',
-			'3.1.1',
-		]);
+		expect(schema.transformPathToOrdinalPosition('stringProp')).toBe('1.1.1');
 	});
 
 	test('should return positions of embedded document properties', () => {
-		expect(schema.transformPathsToOrdinalPositions(['embeddedProp.innerEmbeddedProp'])).toEqual([
-			'9.1.1',
-		]);
+		expect(schema.transformPathToOrdinalPosition('embeddedProp.innerEmbeddedProp')).toBe('9.1.1');
 	});
 
 	test('should return positions of document array properties', () => {
-		expect(schema.transformPathsToOrdinalPositions(['documentArrayProp.docStringProp'])).toEqual([
-			'10.1.1',
-		]);
+		expect(schema.transformPathToOrdinalPosition('documentArrayProp.docStringProp')).toBe('10.1.1');
 	});
 
 	test('should return correct ordinal position if path is to a value', () => {
-		expect(schema.transformPathsToOrdinalPositions(['stringValueProp'])).toEqual(['14.2.1']);
+		expect(schema.transformPathToOrdinalPosition('stringValueProp')).toBe('14.2.1');
 	});
 
 	test('should return correct ordinal position if path is to a subvalue', () => {
-		expect(schema.transformPathsToOrdinalPositions(['stringSubvalueProp'])).toEqual(['14.2.3']);
+		expect(schema.transformPathToOrdinalPosition('stringSubvalueProp')).toBe('14.2.3');
 	});
 
 	test('should return correct ordinal position for array at value position', () => {
-		expect(schema.transformPathsToOrdinalPositions(['stringArrayValueProp'])).toEqual(['15.2.1']);
+		expect(schema.transformPathToOrdinalPosition('stringArrayValueProp')).toBe('15.2.1');
 	});
 });
 

--- a/src/__tests__/Schema.test.ts
+++ b/src/__tests__/Schema.test.ts
@@ -337,6 +337,7 @@ describe('transformPathsToDbPositions', () => {
 	const definition: SchemaDefinition = {
 		stringProp: { type: 'string', path: '1' },
 		stringValueProp: { type: 'string', path: '14.2' },
+		stringSubValueProp: { type: 'string', path: '14.2.3' },
 		numberProp: { type: 'number', path: '2' },
 		booleanProp: { type: 'boolean', path: '3' },
 		isoCalendarDateProp: { type: 'ISOCalendarDate', path: '4' },
@@ -385,6 +386,89 @@ describe('transformPathsToDbPositions', () => {
 
 	test('should return no positions if dotted path is not in schema', () => {
 		expect(schema.transformPathsToDbPositions(['not.here'])).toEqual([]);
+	});
+});
+
+describe('transformPathsToOrdinalPositions', () => {
+	const embeddedDefinition: SchemaDefinition = {
+		innerEmbeddedProp: { type: 'string', path: '9' },
+	};
+	const documentArrayDefinition: SchemaDefinition = {
+		docStringProp: { type: 'string', path: '12' },
+		docNumberProp: { type: 'number', path: '13' },
+	};
+	const definition: SchemaDefinition = {
+		stringProp: { type: 'string', path: '1' },
+		stringValueProp: { type: 'string', path: '14.2' },
+		stringSubvalueProp: { type: 'string', path: '14.2.3' },
+		stringArrayValueProp: [{ type: 'string', path: '15.2' }],
+		numberProp: { type: 'number', path: '2' },
+		booleanProp: { type: 'boolean', path: '3' },
+		isoCalendarDateProp: { type: 'ISOCalendarDate', path: '4' },
+		isoTimeProp: { type: 'ISOTime', path: '5' },
+		isoCalendarDateTimeProp: { type: 'ISOCalendarDateTime', path: '6' },
+		arrayProp: [{ type: 'string', path: '7' }],
+		nestedArrayProp: [[{ type: 'string', path: '8' }]],
+		embeddedProp: new Schema(embeddedDefinition),
+		documentArrayProp: [
+			{
+				docStringProp: { type: 'string', path: '10' },
+				docNumberProp: { type: 'number', path: '11' },
+			},
+		],
+		documentArraySchemaProp: [new Schema(documentArrayDefinition)],
+	};
+	const schema = new Schema(definition);
+
+	test('should return no positions if path list is empty', () => {
+		expect(schema.transformPathsToOrdinalPositions([])).toEqual([]);
+	});
+
+	test('should return positions of specified path', () => {
+		expect(schema.transformPathsToOrdinalPositions(['stringProp'])).toEqual(['1']);
+	});
+
+	test('should return positions of multiple paths', () => {
+		expect(schema.transformPathsToOrdinalPositions(['stringProp', 'booleanProp'])).toEqual([
+			'1',
+			'3',
+		]);
+	});
+
+	test('should return positions of embedded documents', () => {
+		expect(schema.transformPathsToOrdinalPositions(['embeddedProp'])).toEqual(['9']);
+	});
+
+	test('should return positions of embedded document properties', () => {
+		expect(schema.transformPathsToOrdinalPositions(['embeddedProp.innerEmbeddedProp'])).toEqual([
+			'9',
+		]);
+	});
+
+	test('should return positions of document arrays', () => {
+		expect(schema.transformPathsToOrdinalPositions(['documentArrayProp'])).toEqual(['10', '11']);
+	});
+
+	test('should return positions of document array properties', () => {
+		expect(schema.transformPathsToOrdinalPositions(['documentArrayProp.docStringProp'])).toEqual([
+			'10',
+		]);
+	});
+
+	test('should return no positions if dotted path is not in schema', () => {
+		expect(schema.transformPathsToOrdinalPositions(['not.here'])).toEqual([]);
+	});
+
+	test('should return correct ordinal position if path is to a value', () => {
+		expect(schema.transformPathsToOrdinalPositions(['stringValueProp'])).toEqual(['14.2']);
+	});
+
+	test('should return correct ordinal position if path is to a subvalue', () => {
+		expect(schema.transformPathsToOrdinalPositions(['stringSubvalueProp'])).toEqual(['14.2.3']);
+	});
+
+	test('should return correct ordinal position for array at value position', () => {
+		expect(schema.transformPathsToOrdinalPositions(['stringArrayValueProp'])).toEqual(['15.2']);
 	});
 });
 

--- a/src/__tests__/Schema.test.ts
+++ b/src/__tests__/Schema.test.ts
@@ -337,7 +337,6 @@ describe('transformPathsToDbPositions', () => {
 	const definition: SchemaDefinition = {
 		stringProp: { type: 'string', path: '1' },
 		stringValueProp: { type: 'string', path: '14.2' },
-		stringSubValueProp: { type: 'string', path: '14.2.3' },
 		numberProp: { type: 'number', path: '2' },
 		booleanProp: { type: 'boolean', path: '3' },
 		isoCalendarDateProp: { type: 'ISOCalendarDate', path: '4' },

--- a/src/__tests__/Schema.test.ts
+++ b/src/__tests__/Schema.test.ts
@@ -419,7 +419,7 @@ describe('transformPathsToOrdinalPositions', () => {
 	} satisfies SchemaDefinition;
 	const schema = new Schema(definition);
 
-	test('should throw error if path list is empty', () => {
+	test('should throw error if invalid path provided', () => {
 		// @ts-expect-error: intentionally passing invalid argument to test
 		expect(() => schema.transformPathToOrdinalPosition('bad-path')).toThrow(Error);
 	});

--- a/src/__tests__/compileModel.test.ts
+++ b/src/__tests__/compileModel.test.ts
@@ -625,7 +625,7 @@ describe('increment', () => {
 
 	const testSchema = new Schema(testSchemaDefinition);
 
-	test('should return null if database returns null', async () => {
+	test('should throw error if database returns null', async () => {
 		const Model = compileModel(
 			connectionMock,
 			testSchema,
@@ -634,7 +634,7 @@ describe('increment', () => {
 			logHandlerMock,
 		);
 		connectionMock.executeDbSubroutine.mockResolvedValue({ result: null });
-		expect(await Model.increment('id', [{ path: 'prop2', value: 3 }])).toBeNull();
+		await expect(Model.increment('id', [{ path: 'prop2', value: 3 }])).rejects.toThrow(Error);
 	});
 
 	test('should transform key paths to ordinal positions based on IncrementOperations passed in', async () => {

--- a/src/__tests__/compileModel.test.ts
+++ b/src/__tests__/compileModel.test.ts
@@ -625,18 +625,6 @@ describe('increment', () => {
 
 	const testSchema = new Schema(testSchemaDefinition);
 
-	test('should throw error if database returns null', async () => {
-		const Model = compileModel(
-			connectionMock,
-			testSchema,
-			filename,
-			mockDelimiters,
-			logHandlerMock,
-		);
-		connectionMock.executeDbSubroutine.mockResolvedValue({ result: null });
-		await expect(Model.increment('id', [{ path: 'prop2', value: 3 }])).rejects.toThrow(Error);
-	});
-
 	test('should transform key paths to ordinal positions based on IncrementOperations passed in', async () => {
 		const Model = compileModel(
 			connectionMock,
@@ -654,7 +642,7 @@ describe('increment', () => {
 			{
 				filename,
 				id: 'id',
-				operations: [{ path: '2', value: 3 }],
+				operations: [{ path: '2.1.1', value: 3 }],
 				retry: 5,
 				retryDelay: 1,
 			},

--- a/src/__tests__/compileModel.test.ts
+++ b/src/__tests__/compileModel.test.ts
@@ -609,6 +609,70 @@ describe('findByIds', () => {
 	});
 });
 
+describe('increment', () => {
+	const testSchemaDefinition = {
+		prop1: {
+			type: 'string',
+			path: 1,
+			dictionary: 'prop1Dictionary',
+			foreignKey: { file: 'FK_FILE', entityName: 'prop1' },
+		},
+		prop2: { type: 'number', path: 2, dictionary: 'prop2Dictionary' },
+		nestedDocument: {
+			prop3: { type: 'number', path: 3 },
+		},
+	} satisfies SchemaDefinition;
+
+	const testSchema = new Schema(testSchemaDefinition);
+
+	test('should return null if database returns null', async () => {
+		const Model = compileModel(
+			connectionMock,
+			testSchema,
+			filename,
+			mockDelimiters,
+			logHandlerMock,
+		);
+		connectionMock.executeDbSubroutine.mockResolvedValue({ result: null });
+		expect(await Model.increment('id', [{ path: 'prop2', value: 3 }])).toBeNull();
+	});
+
+	test('should transform key paths to ordinal positions based on IncrementOperations passed in', async () => {
+		const Model = compileModel(
+			connectionMock,
+			testSchema,
+			filename,
+			mockDelimiters,
+			logHandlerMock,
+		);
+		connectionMock.executeDbSubroutine.mockResolvedValue({
+			result: { _id: 'id', __v: 'version1', record: '' },
+		});
+		await Model.increment('id', [{ path: 'prop2', value: 3 }]);
+		expect(connectionMock.executeDbSubroutine).toHaveBeenCalledWith(
+			'increment',
+			{
+				filename,
+				id: 'id',
+				operations: [{ path: '2', value: 3 }],
+				retry: 5,
+				retryDelay: 1,
+			},
+			{},
+		);
+	});
+
+	test('should throw error if schema is not defined', async () => {
+		const Model = compileModel(connectionMock, null, filename, mockDelimiters, logHandlerMock);
+		connectionMock.executeDbSubroutine.mockResolvedValue({
+			result: { _id: 'id', __v: 'version1', record: '' },
+		});
+		// @ts-expect-error: intentionally invalid data to trigger error due to no schema being defined
+		await expect(Model.increment('id', [{ path: 'prop2', value: 3 }])).rejects.toThrow(Error);
+		expect(connectionMock.executeDbSubroutine).not.toHaveBeenCalled();
+	});
+});
+
 describe('readFileContentsById', () => {
 	test('should return string from database', async () => {
 		const Model = compileModel(connectionMock, schema, filename, mockDelimiters, logHandlerMock);

--- a/src/compileModel.ts
+++ b/src/compileModel.ts
@@ -71,7 +71,10 @@ export interface ModelIncrementOptions extends ModelDatabaseExecutionOptions {
 
 export type IncrementOperation<TSchema extends Schema | null> = TSchema extends Schema
 	? {
-			path: keyof FlattenDocument<TSchema, Schema | SchemaDefinition | SchemaTypeDefinitionNumber>;
+			path: Extract<
+				keyof FlattenDocument<TSchema, Schema | SchemaDefinition | SchemaTypeDefinitionNumber>,
+				string
+			>;
 			value: number;
 		}
 	: never;

--- a/src/compileModel.ts
+++ b/src/compileModel.ts
@@ -341,11 +341,6 @@ const compileModel = <TSchema extends Schema | null>(
 					...(userDefined && { userDefined }),
 				},
 			);
-			if (data.result == null) {
-				throw new Error(
-					`No result returned from increment operation for file ${this.file} and id ${id}`,
-				);
-			}
 
 			const { _id, __v, record } = data.result;
 			return this.#createModelFromRecordString(record, _id, __v);

--- a/src/compileModel.ts
+++ b/src/compileModel.ts
@@ -397,8 +397,7 @@ const compileModel = <TSchema extends Schema | null>(
 			const incrementSchema = this.schema;
 
 			return operations.map(({ path, value }) => ({
-				// passing one path to transform so get the first element of the returned array. The IncrementOperation type won't allow for parent properties, so should only ever get a single path back from transformation
-				path: incrementSchema.transformPathsToOrdinalPositions([path])[0],
+				path: incrementSchema.transformPathToOrdinalPosition(path),
 				value,
 			}));
 		}

--- a/src/compileModel.ts
+++ b/src/compileModel.ts
@@ -391,7 +391,6 @@ const compileModel = <TSchema extends Schema | null>(
 			operations: IncrementOperation<TSchema>[],
 		): DbSubroutineInputIncrementOperation[] {
 			if (this.schema == null) {
-				// should never get here because increment also checks for null schema, but just in case.
 				throw new Error('Schema must be defined to perform increment operations');
 			}
 			const incrementSchema = this.schema;

--- a/src/compileModel.ts
+++ b/src/compileModel.ts
@@ -314,6 +314,7 @@ const compileModel = <TSchema extends Schema | null>(
 
 		/** Increment fields in a document by values
 		 * @throws {Error} if schema is not defined
+		 * @throws {Error} if no result is returned from increment operation
 		 */
 		public static async increment(
 			id: string,

--- a/src/compileModel.ts
+++ b/src/compileModel.ts
@@ -314,7 +314,6 @@ const compileModel = <TSchema extends Schema | null>(
 
 		/** Increment fields in a document by values
 		 * @throws {Error} if schema is not defined
-		 * @throws {Error} if no result is returned from increment operation
 		 */
 		public static async increment(
 			id: string,

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,7 @@ export {
 	InvalidParameterError,
 	InvalidServerFeaturesError,
 	RecordLockedError,
+	RecordNotFoundError,
 	RecordVersionError,
 	TimeoutError,
 	TransformDataError,

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ export type {
 	ModelConstructorOptions,
 	Model,
 	ModelCompositeValue,
+	IncrementOperation,
 } from './compileModel';
 export {
 	MvisError,

--- a/src/types/DbSubroutineInput.ts
+++ b/src/types/DbSubroutineInput.ts
@@ -46,6 +46,31 @@ export interface DbSubroutineInputFindByIds {
 	projection: number[] | null;
 }
 
+export interface DbSubroutineInputIncrementOperation {
+	/**
+	 * ordinal path to the field to increment ex. 1.2.3
+	 */
+	path: string;
+	/**
+	 * numeric value to increment by
+	 */
+	value: number;
+}
+
+export interface DbSubroutineInputIncrement {
+	filename: string;
+	id: string;
+	operations: DbSubroutineInputIncrementOperation[];
+	/**
+	 * number of retries to perform
+	 */
+	retry: number;
+	/**
+	 * delay between retries in seconds
+	 */
+	retryDelay: number;
+}
+
 export interface DbSubroutineInputReadFileContentsById {
 	filename: string;
 	id: string;
@@ -66,6 +91,7 @@ export type DbActionSubroutineInputTypes = DbSubroutinePayload<
 	| DbSubroutineInputFind
 	| DbSubroutineInputFindById
 	| DbSubroutineInputFindByIds
+	| DbSubroutineInputIncrement
 	| DbSubroutineInputReadFileContentsById
 	| DbSubroutineInputGetServerInfo
 >;
@@ -75,6 +101,7 @@ export interface DbSubroutineInputOptionsMap {
 	find: DbSubroutineInputFind;
 	findById: DbSubroutineInputFindById;
 	findByIds: DbSubroutineInputFindByIds;
+	increment: DbSubroutineInputIncrement;
 	readFileContentsById: DbSubroutineInputReadFileContentsById;
 	getServerInfo: DbSubroutineInputGetServerInfo;
 	save: DbSubroutineInputSave;

--- a/src/types/DbSubroutineInput.ts
+++ b/src/types/DbSubroutineInput.ts
@@ -48,11 +48,11 @@ export interface DbSubroutineInputFindByIds {
 
 export interface DbSubroutineInputIncrementOperation {
 	/**
-	 * ordinal path to the field to increment ex. 1.2.3
+	 * Ordinal path to the field to increment ex. 1.2.3
 	 */
 	path: string;
 	/**
-	 * numeric value to increment by
+	 * Numeric value to increment by
 	 */
 	value: number;
 }
@@ -62,11 +62,11 @@ export interface DbSubroutineInputIncrement {
 	id: string;
 	operations: DbSubroutineInputIncrementOperation[];
 	/**
-	 * number of retries to perform
+	 * Number of retries to perform
 	 */
 	retry: number;
 	/**
-	 * delay between retries in seconds
+	 * Delay between retries in seconds
 	 */
 	retryDelay: number;
 }

--- a/src/types/DbSubroutineOutput.ts
+++ b/src/types/DbSubroutineOutput.ts
@@ -31,6 +31,11 @@ export interface DbSubroutineOutputFindByIds {
 }
 export type DbSubroutineResponseFindByIds = DbSubroutineResponse<DbSubroutineOutputFindByIds>;
 
+export interface DbSubroutineOutputIncrement {
+	result: DbDocument | null;
+}
+export type DbSubroutineResponseIncrement = DbSubroutineResponse<DbSubroutineOutputIncrement>;
+
 export interface DbSubroutineOutputReadFileContentsById {
 	result: string;
 }
@@ -76,6 +81,7 @@ export type DbSubroutineResponseTypes =
 	| DbSubroutineResponseFind
 	| DbSubroutineResponseFindById
 	| DbSubroutineResponseFindByIds
+	| DbSubroutineResponseIncrement
 	| DbSubroutineResponseReadFileContentsById
 	| DbSubroutineResponseGetServerInfo
 	| DbSubroutineResponseSave;
@@ -85,6 +91,7 @@ export interface DbSubroutineResponseTypesMap {
 	find: DbSubroutineResponseFind;
 	findById: DbSubroutineResponseFindById;
 	findByIds: DbSubroutineResponseFindByIds;
+	increment: DbSubroutineResponseIncrement;
 	readFileContentsById: DbSubroutineResponseReadFileContentsById;
 	getServerInfo: DbSubroutineResponseGetServerInfo;
 	save: DbSubroutineResponseSave;

--- a/src/types/DbSubroutineOutput.ts
+++ b/src/types/DbSubroutineOutput.ts
@@ -32,7 +32,7 @@ export interface DbSubroutineOutputFindByIds {
 export type DbSubroutineResponseFindByIds = DbSubroutineResponse<DbSubroutineOutputFindByIds>;
 
 export interface DbSubroutineOutputIncrement {
-	result: DbDocument | null;
+	result: DbDocument;
 }
 export type DbSubroutineResponseIncrement = DbSubroutineResponse<DbSubroutineOutputIncrement>;
 

--- a/src/unibasicTemplates/main.njk
+++ b/src/unibasicTemplates/main.njk
@@ -96,3 +96,4 @@ response:
 {% include "./subroutines/external/getServerInfo.njk" %}
 {% include "./subroutines/external/readFileContentsById.njk" %}
 {% include "./subroutines/external/save.njk" %}
+{% include "./subroutines/external/increment.njk" %}

--- a/src/unibasicTemplates/subroutines/external/increment.njk
+++ b/src/unibasicTemplates/subroutines/external/increment.njk
@@ -16,7 +16,7 @@ if udoGetProperty(options, 'id', recordId, type) then
 end
 
 * get the number of retries to perform if the record is locked
-if udoGetProperty(options, 'retry', retry, type) then
+if udoGetProperty(options, 'retry', retryMax, type) then
   call error_handler(ERROR_MALFORMED_INPUT, output)
   go returnFromSub
 end
@@ -47,11 +47,23 @@ tries=0
 lockSuccessful=0
 
 loop
+  *** a layer of abstraction where an internal subroutine is called and returns status of the read.
+  *** This layer will handle the retry loop
   readu record from f.file, recordId on error
     call error_handler(ERROR_RECORD_READ, output)
     go closeAndReturnFromSub
+  end locked
+    if tries > retryMax then
+      call error_handler(ERROR_RECORD_LOCKED, output)
+      go closeAndReturnFromSub
+    end else
+      tries+= 1
+    end
   end then
+    * call increment internal subroutine
   end else
+    call error_handler(ERROR_RECORD_NOT_FOUND, output)
+    go closeAndReturnFromSub
   end
 repeat
 

--- a/src/unibasicTemplates/subroutines/external/increment.njk
+++ b/src/unibasicTemplates/subroutines/external/increment.njk
@@ -73,7 +73,6 @@ loop
     end else
       tries+= 1
       sleep retryDelay
-      continue; * try again
     end
   end then
     * lock successful get out of read lock loop
@@ -81,7 +80,7 @@ loop
   end else
     * record not found
     call error_handler(ERROR_RECORD_NOT_FOUND, output)
-    go closeAndReturnFromSub
+    go closeReleaseAndReturnFromSub
   end
 repeat
 
@@ -119,6 +118,11 @@ loop while processCount lt operationsCount
   end
 
   * parse out path.
+  pathMatchTest = path match "1n'.'1n'.'1n"
+  if pathMatchTest eq 0 then
+    call error_handler(ERROR_MALFORMED_INPUT, output)
+    go closeReleaseAndReturnFromSub
+  end
   * get attribute position
   attributePosition = field(path, '.', 1, 1)
   * get value position
@@ -132,8 +136,8 @@ repeat
 
 * create null projection
 if udoCreate(UDO_NULL, projection) then
-   call error_handler(ERROR_UDO, output)
-   go closeAndReturnFromSub
+  call error_handler(ERROR_UDO, output)
+  go closeAndReturnFromSub
 end
 
 * write out record

--- a/src/unibasicTemplates/subroutines/external/increment.njk
+++ b/src/unibasicTemplates/subroutines/external/increment.njk
@@ -1,0 +1,64 @@
+subroutine mvom_increment(options, output)
+* increment values and return a document given a filename, the paths to the values to increment, and the values to increment by
+{% include "../../constants/udo.njk" %}
+{% include "../../constants/error.njk" %}
+
+* get the filename from the options
+if udoGetProperty(options, 'filename', filename, type) then
+  call error_handler(ERROR_MALFORMED_INPUT, output)
+  go returnFromSub
+end
+
+* get the recordId from the options
+if udoGetProperty(options, 'id', recordId, type) then
+  call error_handler(ERROR_MALFORMED_INPUT, output)
+  go returnFromSub
+end
+
+* get the number of retries to perform if the record is locked
+if udoGetProperty(options, 'retry', retry, type) then
+  call error_handler(ERROR_MALFORMED_INPUT, output)
+  go returnFromSub
+end
+
+* get the retry delay between retries
+if udoGetProperty(options, 'retryDelay', retryDelay, type) then
+  call error_handler(ERROR_MALFORMED_INPUT, output)
+  go returnFromSub
+end
+
+* get the increment operations
+if udoGetProperty(options, 'incrementOperations', operations, type) then
+  call error_handler(ERROR_MALFORMED_INPUT, output)
+  go returnFromSub
+end
+
+* open the file
+open filename to f.file on error
+  call error_handler(ERROR_FILE_OPEN, output)
+  go returnFromSub
+end else
+  call error_handler(ERROR_FILE_OPEN, output)
+  go returnFromSub
+end
+
+* read and lock the record from the file
+tries=0
+lockSuccessful=0
+
+loop
+  readu record from f.file, recordId on error
+    call error_handler(ERROR_RECORD_READ, output)
+    go closeAndReturnFromSub
+  end then
+  end else
+  end
+repeat
+
+
+closeAndReturnFromSub:
+close f.file on error null
+* fall through to return
+
+returnFromSub:
+return; * returning to caller

--- a/src/unibasicTemplates/subroutines/external/increment.njk
+++ b/src/unibasicTemplates/subroutines/external/increment.njk
@@ -1,5 +1,5 @@
 subroutine mvom_increment(options, output)
-* increment values and return a document given a filename, the paths to the values to increment, and the values to increment by
+* increment values and return the updated document given a filename, the paths to the values to increment, and the values to increment by
 {% include "../../constants/udo.njk" %}
 {% include "../../constants/error.njk" %}
 
@@ -27,8 +27,24 @@ if udoGetProperty(options, 'retryDelay', retryDelay, type) then
   go returnFromSub
 end
 
-* get the increment operations
-if udoGetProperty(options, 'incrementOperations', operations, type) then
+* get the array of operations from the options
+if udoGetProperty(options, 'operations', operations, type) then
+  call error_handler(ERROR_MALFORMED_INPUT, output)
+  go returnFromSub
+end
+
+operationsCount = 0
+begin case
+  case type ne UDO_ARRAY
+    call error_handler(ERROR_MALFORMED_INPUT, output)
+    go returnFromSub
+  case udoArrayGetSize(operations, operationsCount) ne UDO_SUCCESS
+    call error_handler(ERROR_UDO, output)
+    go returnFromSub
+end case
+
+* make sure the array of operations passed in wasn't empty
+if operationsCount eq 0 then
   call error_handler(ERROR_MALFORMED_INPUT, output)
   go returnFromSub
 end
@@ -43,12 +59,9 @@ end else
 end
 
 * read and lock the record from the file
-tries=0
-lockSuccessful=0
+tries = 0
 
 loop
-  *** a layer of abstraction where an internal subroutine is called and returns status of the read.
-  *** This layer will handle the retry loop
   readu record from f.file, recordId on error
     call error_handler(ERROR_RECORD_READ, output)
     go closeAndReturnFromSub
@@ -58,15 +71,110 @@ loop
       go closeAndReturnFromSub
     end else
       tries+= 1
+      sleep retryDelay
+      continue; * try again
     end
   end then
-    * call increment internal subroutine
+    * lock successful get out of read lock loop
+    exit
   end else
+    * record not found
     call error_handler(ERROR_RECORD_NOT_FOUND, output)
     go closeAndReturnFromSub
   end
 repeat
 
+* increment fields
+processCount = 0
+loop while processCount lt operationsCount
+  processCount += 1
+
+  * get the next operation from the array
+  if udoArrayGetNextItem(operations, operation, type) ne UDO_SUCCESS then
+    call error_handler(ERROR_UDO, output)
+    go closeReleaseAndReturnFromSub
+  end
+
+  * get the path
+  if udoGetProperty(operation, 'path', path, type) then
+    call error_handler(ERROR_MALFORMED_INPUT, output)
+    go closeReleaseAndReturnFromSub
+  end
+  * path must be a string
+  if type ne UDO_STRING then
+    call error_handler(ERROR_MALFORMED_INPUT, output)
+    go closeReleaseAndReturnFromSub
+  end
+
+  * get the value to increment by
+  if udoGetProperty(operation, 'value', value, type) then
+    call error_handler(ERROR_MALFORMED_INPUT, output)
+    go closeReleaseAndReturnFromSub
+  end
+  * value must be numeric
+  if type ne UDO_NUMBER then
+    call error_handler(ERROR_MALFORMED_INPUT, output)
+    go closeReleaseAndReturnFromSub
+  end
+
+  * parse out path.
+  * get attribute position
+  attributePosition = field(path, '.', 1, 1)
+  * get value position
+  valuePosition = field(path, '.', 2, 1)
+  * get subvalue position
+  subvaluePosition = field(path, '.', 3, 1)
+
+  * perform incrementing
+  record<attributePosition, valuePosition, subvaluePosition>+= value
+repeat
+
+* create null projection
+if udoCreate(UDO_NULL, projection) then
+   call error_handler(ERROR_UDO, output)
+   go closeAndReturnFromSub
+end
+
+* write out record
+write record on f.file, recordId on error
+  statusCode = status()
+  begin case
+    case statusCode eq STATUS_WRITE_SYSTEM_ERROR
+      call error_handler(ERROR_RECORD_WRITE, output)
+    case statusCode eq STATUS_WRITE_TRIGGER_CONSTRAINT
+      call error_handler(ERROR_RECORD_WRITE_TRIGGER_CONSTRAINT, output)
+    case statusCode eq STATUS_WRITE_TRIGGER_ERROR
+      call error_handler(ERROR_RECORD_WRITE_TRIGGER_ERROR, output)
+    case statusCode eq STATUS_WRITE_DUPLICATE_INDEX
+      call error_handler(ERROR_RECORD_WRITE_DUPLICATE_INDEX, output)
+    case 1
+      * Unknown error status code
+      call error_handler(ERROR_RECORD_WRITE_UNKNOWN, output)
+  end case
+
+  go closeAndReturnFromSub
+end
+
+close f.file on error null
+
+* format the modified record into an object structure
+call format_document(record, recordId, projection, document, errorCode)
+if errorCode then
+  call error_handler(errorCode, output)
+  go returnFromSub
+end
+
+* set the result property
+if udoSetProperty(output, 'result', document) then
+  call error_handler(ERROR_UDO, output)
+  go returnFromSub
+end
+
+go returnFromSub;* skip close and release behaviors
+
+closeReleaseAndReturnFromSub:
+release f.file, recordId on error null
+* fall through to close and return
 
 closeAndReturnFromSub:
 close f.file on error null

--- a/src/unibasicTemplates/subroutines/external/increment.njk
+++ b/src/unibasicTemplates/subroutines/external/increment.njk
@@ -2,6 +2,7 @@ subroutine mvom_increment(options, output)
 * increment values and return the updated document given a filename, the paths to the values to increment, and the values to increment by
 {% include "../../constants/udo.njk" %}
 {% include "../../constants/error.njk" %}
+{% include "../../constants/status.njk" %}
 
 * get the filename from the options
 if udoGetProperty(options, 'filename', filename, type) then

--- a/src/unibasicTemplates/subroutines/external/increment.njk
+++ b/src/unibasicTemplates/subroutines/external/increment.njk
@@ -118,8 +118,7 @@ loop while processCount lt operationsCount
   end
 
   * parse out path.
-  pathMatchTest = path match "1n'.'1n'.'1n"
-  if pathMatchTest eq 0 then
+  if not(path match "1n'.'1n'.'1n") then
     call error_handler(ERROR_MALFORMED_INPUT, output)
     go closeReleaseAndReturnFromSub
   end

--- a/src/unibasicTemplates/subroutines/external/save.njk
+++ b/src/unibasicTemplates/subroutines/external/save.njk
@@ -102,8 +102,8 @@ end
 
 * create null projection
 if udoCreate(UDO_NULL, projection) then
-   call error_handler(ERROR_UDO, output)
-   go closeAndReturnFromSub
+  call error_handler(ERROR_UDO, output)
+  go closeAndReturnFromSub
 end
 
 * write out record


### PR DESCRIPTION
### Summary

This PR implements the new `increment` operation.

#### TypeScript Changes

- Created Input and Output types for new `increment` operation
- Created async static method `increment` on dynamically generated Model class via `compileModel`.
- Created `transformPathToOrdinalPosition` to transform an increment operation input key path to its ordinal position.
- Updated `Connection` to handle new `RecordNotFoundError`.

#### UniBasic Changes

- Created unibasicTemplate - `increment.njk`
    - validates increment operation input
    - Has a read lock loop to handle locked records.
        -  sleeps according to the passed in retry delay.
        - returns `RecordLockedError` when retry max is exceeded
    - returns new `RecordNotFoundError` error when `else` statement executes on `readu`.
    -  writes record after performing incrementing.
    - returns the updated document
  
### Testing Notes

Ran tests using MVOM:

- incrementing a record that does not exist - received `RecordNotFoundError`
- incrementing one field - field was incremented, updated document returned
- incremented multiple fields - fields were incremented, updated document returned
- incremented nested field - nested field was incremented, updated document returned
- incremented value position - value position was incremented
- incremented multiple value positions - value positions were incremented
- incremented sub value positions - sub value positions were incremented
- incremented while record was locked - retries were performed - `RecordLockedError` returned.