### PR TITLE
Improve the type of schema type path to be a union of tuples

### DIFF
--- a/src/Schema.ts
+++ b/src/Schema.ts
@@ -28,6 +28,7 @@ import type {
 	SchemaTypeDefinitionNumber,
 	SchemaTypeDefinitionScalar,
 	SchemaTypeDefinitionString,
+	SchemaTypePath,
 } from './schemaType';
 import type {
 	DataTransformer,
@@ -203,7 +204,7 @@ class Schema<
 	private readonly definition: TSchemaDefinition;
 
 	/** Map of the compiled schema object position paths */
-	private readonly positionPaths: Map<string, number[]>;
+	private readonly positionPaths: Map<string, SchemaTypePath>;
 
 	/** Map of all subdocument schemas represented in this Schema with parentPath as key */
 	private readonly subdocumentSchemas: Map<string, Schema>;
@@ -237,7 +238,7 @@ class Schema<
 	}
 
 	/** Get all multivalue data paths in this schema and its subdocument schemas */
-	public getMvPaths(): number[][] {
+	public getMvPaths(): SchemaTypePath[] {
 		return Array.from(this.subdocumentSchemas.values()).reduce(
 			(mvPaths, schema) => mvPaths.concat(schema.getMvPaths()),
 			Array.from(this.positionPaths.values()).slice(),
@@ -337,7 +338,7 @@ class Schema<
 	 * Get all positionPaths with path as key and position array as value including children schemas
 	 * e.g. parent field 'foo' has a child schema which has ["bar",[2]], the returned positionPath will be ["foo.bar",[2]].
 	 */
-	private getPositionPaths(): Map<string, number[]> {
+	private getPositionPaths(): Map<string, SchemaTypePath> {
 		// merge the positionPaths from subdocumentSchemas with parentPath appended by the childPath recursively
 		return Array.from(this.subdocumentSchemas.entries()).reduce((mvPaths, [parentKey, schema]) => {
 			const childrenPositions = schema.getPositionPaths();
@@ -467,9 +468,7 @@ class Schema<
 		}
 
 		// add to mvPath array
-		if (schemaTypeValue.path != null) {
-			this.positionPaths.set(keyPath, schemaTypeValue.path);
-		}
+		this.positionPaths.set(keyPath, schemaTypeValue.path);
 
 		// update dictPaths
 		if (schemaTypeValue.dictionary != null) {

--- a/src/schemaType/BaseScalarType.ts
+++ b/src/schemaType/BaseScalarType.ts
@@ -8,7 +8,7 @@ import type {
 	MvDataType,
 	MvRecord,
 } from '../types';
-import BaseSchemaType, { type Validator } from './BaseSchemaType';
+import BaseSchemaType, { type SchemaTypeDefinitionPath, type Validator } from './BaseSchemaType';
 import type { SchemaTypeDefinitionBoolean } from './BooleanType';
 import type { SchemaTypeDefinitionISOCalendarDateTime } from './ISOCalendarDateTimeType';
 import type { SchemaTypeDefinitionISOCalendarDate } from './ISOCalendarDateType';
@@ -31,6 +31,8 @@ export type SchemaTypeDefinitionScalar =
 	| SchemaTypeDefinitionString;
 
 type RecordSetType = string | null | (string | null | (string | null)[])[];
+
+export type SchemaTypePath = [number] | [number, number] | [number, number, number];
 // #endregion
 
 /** Abstract Scalar Schema Type */
@@ -39,7 +41,7 @@ abstract class BaseScalarType extends BaseSchemaType implements DataTransformer 
 	public readonly definition: SchemaTypeDefinitionScalar;
 
 	/** 0-indexed Array path */
-	public readonly path: number[];
+	public readonly path: SchemaTypePath;
 
 	/** Multivalue dictionary id */
 	public readonly dictionary: string | null;
@@ -172,17 +174,19 @@ abstract class BaseScalarType extends BaseSchemaType implements DataTransformer 
 	 * Convert a 1-index string array path definition (e.g. '1.1.1') to a 0-index array path definition (e.g. [0, 0, 0])
 	 * @throws {@link InvalidParameterError} Path definition must be a string of integers split by periods
 	 */
-	private normalizeMvPath(path: string | number): number[] {
-		return toPath(path).map((val) => {
-			const numVal = +val;
-			if (!Number.isInteger(numVal) || numVal < 1) {
-				throw new InvalidParameterError({
-					message: 'Path definition must be a string of integers split by periods',
-					parameterName: 'path',
-				});
-			}
-			return numVal - 1;
-		});
+	private normalizeMvPath(path: SchemaTypeDefinitionPath): SchemaTypePath {
+		return toPath(path)
+			.slice(0, 3)
+			.map((val) => {
+				const numVal = +val;
+				if (!Number.isInteger(numVal) || numVal < 1) {
+					throw new InvalidParameterError({
+						message: 'Path definition must be a string of integers split by periods',
+						parameterName: 'path',
+					});
+				}
+				return numVal - 1;
+			}) as SchemaTypePath;
 	}
 
 	/** Encrypt a transformed property */

--- a/src/schemaType/BaseSchemaType.ts
+++ b/src/schemaType/BaseSchemaType.ts
@@ -3,8 +3,14 @@ import type { MvAttribute, MvRecord } from '../types';
 import { ensureArray } from '../utils';
 
 // #region types
+export type SchemaTypeDefinitionPath =
+	| `${number}`
+	| `${number}.${number}`
+	| `${number}.${number}.${number}`
+	| number;
+
 export interface SchemaTypeDefinitionBase {
-	path: `${number}` | `${number}.${number}` | `${number}.${number}.${number}` | number;
+	path: SchemaTypeDefinitionPath;
 	dictionary?: string;
 	required?: boolean;
 	encrypted?: boolean;

--- a/src/schemaType/index.ts
+++ b/src/schemaType/index.ts
@@ -1,6 +1,10 @@
 export { default as ArrayType } from './ArrayType';
 export { default as BaseScalarArrayType } from './BaseScalarArrayType';
-export { default as BaseScalarType, type SchemaTypeDefinitionScalar } from './BaseScalarType';
+export {
+	default as BaseScalarType,
+	type SchemaTypeDefinitionScalar,
+	type SchemaTypePath,
+} from './BaseScalarType';
 export { default as BaseSchemaType } from './BaseSchemaType';
 export { default as BooleanType, type SchemaTypeDefinitionBoolean } from './BooleanType';
 export { default as DocumentArrayType } from './DocumentArrayType';


### PR DESCRIPTION
Currently the type of the `path` property in the `BaseScalarType` is `number[]`. However, this is misleading as a path is really a numeric tuple of length 1, 2, or 3.

This PR introduces a new type alias `SchemaTypeDefinitionPath` which was the type that could be supplied to `SchemaTypeDefinitionBase` as the `path` property. Additionally, it introduces new type alias `SchemaTypePath` which is a 1 to 3 length numeric tuple which will be the type of the `path` property in the `BaseScalarType`. This type is used in all places where the schema type's path was previously used but defined as `number[]`.

Finally, the `normalizeMvPath` method in the `BaseScalarType` was tightened up so that it will ensure that a maximum of 3 positions will be used in the `path` tuple.