### PR TITLE
Fix unreported error condition in save subroutine

### DIFF
--- a/src/unibasicTemplates/subroutines/external/save.njk
+++ b/src/unibasicTemplates/subroutines/external/save.njk
@@ -59,7 +59,7 @@ end then
     originalRecordHash = ''
   end else
     if digest('MD5', originalRecord, 1, originalRecordHash) then
-      errorCode = ERROR_DIGEST_HASH
+      call error_handler(ERROR_DIGEST_HASH, output)
       go closeReleaseAndReturnFromSub
     end
 


### PR DESCRIPTION
In the `save` basic subroutine there is an error check if the `digest` function fails. However, this code is not properly handling the error and is merely exiting without finishing the execution of the `save` subroutine or recording the error.

This PR updates the `save` subroutine so that the error will be properly recorded.