### PR TITLE
Change _raw from conditionally undefined to conditionally never

### DIFF
--- a/src/Document.ts
+++ b/src/Document.ts
@@ -36,7 +36,7 @@ export type DocumentCompositeValue<TSchema extends Schema | null> = TSchema exte
 class Document<TSchema extends Schema | null> {
 	[key: string]: unknown;
 
-	public _raw: TSchema extends Schema ? undefined : MvRecord;
+	public _raw!: TSchema extends Schema ? never : MvRecord;
 
 	/** Array of any errors which occurred during transformation from the database */
 	public _transformationErrors: TransformDataError[];
@@ -62,9 +62,9 @@ class Document<TSchema extends Schema | null> {
 			_transformationErrors: { configurable: false, enumerable: false, writable: false },
 		});
 
-		this._raw = (schema == null ? this.#record : undefined) as TSchema extends Schema
-			? undefined
-			: MvRecord;
+		if (schema == null) {
+			this._raw = this.#record as TSchema extends Schema ? never : MvRecord;
+		}
 
 		this.#transformRecordToDocument();
 

--- a/src/__tests__/Document.test.ts
+++ b/src/__tests__/Document.test.ts
@@ -1020,8 +1020,8 @@ describe('type inference', () => {
 		const test2: Equals<DocumentResult['prop2'], number | null> = true;
 		expect(test2).toBe(true);
 
-		// _raw should be undefined since there is a schema
-		const test3: Equals<DocumentResult['_raw'], undefined> = true;
+		// _raw should be never since there is a schema
+		const test3: Equals<DocumentResult['_raw'], never> = true;
 		expect(test3).toBe(true);
 
 		// any other property should be unknown

--- a/src/__tests__/compileModel.test.ts
+++ b/src/__tests__/compileModel.test.ts
@@ -966,8 +966,8 @@ describe('type inference', () => {
 			const test2: Equals<Result['prop2'], number | null> = true;
 			expect(test2).toBe(true);
 
-			// _raw should be undefined since there is a schema
-			const test3: Equals<Result['_raw'], undefined> = true;
+			// _raw should be never since there is a schema
+			const test3: Equals<Result['_raw'], never> = true;
 			expect(test3).toBe(true);
 
 			// any other property should be unknown
@@ -987,8 +987,8 @@ describe('type inference', () => {
 			const test2: Equals<Result['prop2'], number | null> = true;
 			expect(test2).toBe(true);
 
-			// _raw should be undefined since there is a schema
-			const test3: Equals<Result['_raw'], undefined> = true;
+			// _raw should be never since there is a schema
+			const test3: Equals<Result['_raw'], never> = true;
 			expect(test3).toBe(true);
 
 			// any other property should be unknown
@@ -1008,8 +1008,8 @@ describe('type inference', () => {
 			const test2: Equals<Result['prop2'], number | null> = true;
 			expect(test2).toBe(true);
 
-			// _raw should be undefined since there is a schema
-			const test3: Equals<Result['_raw'], undefined> = true;
+			// _raw should be never since there is a schema
+			const test3: Equals<Result['_raw'], never> = true;
 			expect(test3).toBe(true);
 
 			// any other property should be unknown
@@ -1029,8 +1029,8 @@ describe('type inference', () => {
 			const test2: Equals<Result['prop2'], number | null> = true;
 			expect(test2).toBe(true);
 
-			// _raw should be undefined since there is a schema
-			const test3: Equals<Result['_raw'], undefined> = true;
+			// _raw should be never since there is a schema
+			const test3: Equals<Result['_raw'], never> = true;
 			expect(test3).toBe(true);
 
 			// any other property should be unknown
@@ -1050,8 +1050,8 @@ describe('type inference', () => {
 			const test2: Equals<Result['prop2'], number | null> = true;
 			expect(test2).toBe(true);
 
-			// _raw should be undefined since there is a schema
-			const test3: Equals<Result['_raw'], undefined> = true;
+			// _raw should be never since there is a schema
+			const test3: Equals<Result['_raw'], never> = true;
 			expect(test3).toBe(true);
 
 			// any other property should be unknown
@@ -1071,8 +1071,8 @@ describe('type inference', () => {
 			const test2: Equals<Result['prop2'], number | null> = true;
 			expect(test2).toBe(true);
 
-			// _raw should be undefined since there is a schema
-			const test3: Equals<Result['_raw'], undefined> = true;
+			// _raw should be never since there is a schema
+			const test3: Equals<Result['_raw'], never> = true;
 			expect(test3).toBe(true);
 
 			// any other property should be unknown


### PR DESCRIPTION
#697 modified the `_raw` property of a document so that it was only conditionally undefined if the document did not have a `Schema` associated with it. However, this change had the side-effect of making the `_raw` property an object key in 100% of document instances whereas it was previously only conditionally added as a property. There is a subtle nuance to a property not being present and being present but undefined, and this exposed that nuance.

This PR changes things slightly such that the `_raw` property will only be assigned a value (and thus only become an object property) if there is no schema. If a schema is present then the type of `_raw` will be `never` and it will not be assigned.