### PR TITLE
Internal Write Subroutine to be Used in save and increment

### DIFF
--- a/src/unibasicTemplates/main.njk
+++ b/src/unibasicTemplates/main.njk
@@ -88,6 +88,7 @@ response:
 {% include "./subroutines/internal/setup.njk" %}
 {% include "./subroutines/internal/teardown.njk" %}
 {% include "./subroutines/internal/validateForeignKeys.njk" %}
+{% include "./subroutines/internal/writeRecord.njk" %}
 
 {% include "./subroutines/external/deleteById.njk" %}
 {% include "./subroutines/external/find.njk" %}

--- a/src/unibasicTemplates/subroutines/external/increment.njk
+++ b/src/unibasicTemplates/subroutines/external/increment.njk
@@ -2,7 +2,6 @@ subroutine mvom_increment(options, output)
 * increment values and return the updated document given a filename, the paths to the values to increment, and the values to increment by
 {% include "../../constants/udo.njk" %}
 {% include "../../constants/error.njk" %}
-{% include "../../constants/status.njk" %}
 
 * get the filename from the options
 if udoGetProperty(options, 'filename', filename, type) then
@@ -140,22 +139,9 @@ if udoCreate(UDO_NULL, projection) then
 end
 
 * write out record
-write record on f.file, recordId on error
-  statusCode = status()
-  begin case
-    case statusCode eq STATUS_WRITE_SYSTEM_ERROR
-      call error_handler(ERROR_RECORD_WRITE, output)
-    case statusCode eq STATUS_WRITE_TRIGGER_CONSTRAINT
-      call error_handler(ERROR_RECORD_WRITE_TRIGGER_CONSTRAINT, output)
-    case statusCode eq STATUS_WRITE_TRIGGER_ERROR
-      call error_handler(ERROR_RECORD_WRITE_TRIGGER_ERROR, output)
-    case statusCode eq STATUS_WRITE_DUPLICATE_INDEX
-      call error_handler(ERROR_RECORD_WRITE_DUPLICATE_INDEX, output)
-    case 1
-      * Unknown error status code
-      call error_handler(ERROR_RECORD_WRITE_UNKNOWN, output)
-  end case
-
+call write_record(record, recordId, f.file, errorCode)
+if errorCode then
+  call error_handler(errorCode, output)
   go closeAndReturnFromSub
 end
 

--- a/src/unibasicTemplates/subroutines/external/save.njk
+++ b/src/unibasicTemplates/subroutines/external/save.njk
@@ -2,7 +2,6 @@ subroutine mvom_save(options, output)
 * save a document given a filename, record id, and record contents
 {% include "../../constants/udo.njk" %}
 {% include "../../constants/error.njk" %}
-{% include "../../constants/status.njk" %}
 
 * get the filename from the options
 if udoGetProperty(options, 'filename', filename, type) then
@@ -107,22 +106,9 @@ if udoCreate(UDO_NULL, projection) then
 end
 
 * write out record
-write record on f.file, recordId on error
-  statusCode = status()
-  begin case
-    case statusCode eq STATUS_WRITE_SYSTEM_ERROR
-      call error_handler(ERROR_RECORD_WRITE, output)
-    case statusCode eq STATUS_WRITE_TRIGGER_CONSTRAINT
-      call error_handler(ERROR_RECORD_WRITE_TRIGGER_CONSTRAINT, output)
-    case statusCode eq STATUS_WRITE_TRIGGER_ERROR
-      call error_handler(ERROR_RECORD_WRITE_TRIGGER_ERROR, output)
-    case statusCode eq STATUS_WRITE_DUPLICATE_INDEX
-      call error_handler(ERROR_RECORD_WRITE_DUPLICATE_INDEX, output)
-    case 1
-      * Unknown error status code
-      call error_handler(ERROR_RECORD_WRITE_UNKNOWN, output)
-  end case
-
+call write_record(record, recordId, f.file, errorCode)
+if errorCode then
+  call error_handler(errorCode, output)
   go closeAndReturnFromSub
 end
 

--- a/src/unibasicTemplates/subroutines/internal/writeRecord.njk
+++ b/src/unibasicTemplates/subroutines/internal/writeRecord.njk
@@ -1,0 +1,26 @@
+subroutine write_record(record, recordId, f.file, errorCode)
+* write a record to the file provided and check status
+{% include "../../constants/error.njk" %}
+{% include "../../constants/status.njk" %}
+
+errorCode = ''
+
+write record on f.file, recordId on error
+  statusCode = status()
+  begin case
+    case statusCode eq STATUS_WRITE_SYSTEM_ERROR
+      errorCode = ERROR_RECORD_WRITE
+    case statusCode eq STATUS_WRITE_TRIGGER_CONSTRAINT
+      errorCode = ERROR_RECORD_WRITE_TRIGGER_CONSTRAINT
+    case statusCode eq STATUS_WRITE_TRIGGER_ERROR
+      errorCode = ERROR_RECORD_WRITE_TRIGGER_ERROR
+    case statusCode eq STATUS_WRITE_DUPLICATE_INDEX
+      errorCode = ERROR_RECORD_WRITE_DUPLICATE_INDEX
+    case 1
+      * Unknown error status code
+      errorCode = ERROR_RECORD_WRITE_UNKNOWN
+  end case
+end
+
+returnFromSub:
+return; * returning to caller


### PR DESCRIPTION
### Summary

This PR creates an internal `write_record` subroutine to be used by both save and increment.
This prevents duplicated logic between the save and increment operations.

### Reviewers

@shawnmcknight 