### PR TITLE
Export ModelIncrementResult from index.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ export type {
 	Model,
 	ModelCompositeValue,
 	IncrementOperation,
+	ModelIncrementResult,
 } from './compileModel';
 export {
 	MvisError,


### PR DESCRIPTION
### Summary

This PR exports the new `ModelIncrementResult` type for use by consumers when calling `increment`.

### Reviewers

@shawnmcknight