### PR TITLE
Object Arrays Documentation

### DIFF
--- a/website/docs/03 - Schema/06 - Object Arrays.md
+++ b/website/docs/03 - Schema/06 - Object Arrays.md
@@ -30,8 +30,6 @@ const schemaDefinition = {
         dictionary: 'STRING_ASSOC_PROP1',
         required: true,
       },
-    },
-    {
       associativeProperty2: {
         type: 'number',
         path: 2,


### PR DESCRIPTION
There should be a single object with multiple fields inside the array to create associative properties, instead of multiple objects with a single field.