### PR TITLE
Prepare 3.0.0-rc.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.0-rc.5]
+
+### Added
+
+- New `RecordNotFoundError` error was created to be thrown when a record cannot be found in the database. [#740](https://github.com/STORIS/mvom/pull/740)
+- New Increment operation is now supported on numeric fields. The operation will increment the value at the path specified by the amount specified. [#750](https://github.com/STORIS/mvom/pull/750)
+- New internal unibasic subroutine `writeRecord` was created to be shared by `save` and `increment` operations for writes to the database. [#756](https://github.com/STORIS/mvom/pull/756)
+- `increment` operation returns both the original and updated document. [#757](https://github.com/STORIS/mvom/pull/757)
+- Exporting the `ModelIncrementResult` type from the main entry point. [#758](https://github.com/STORIS/mvom/pull/758)
+
 ## [3.0.0-rc.4]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - New `RecordNotFoundError` error was created to be thrown when a record cannot be found in the database. [#740](https://github.com/STORIS/mvom/pull/740)
-- New Increment operation is now supported on numeric fields. The operation will increment the value at the path specified by the amount specified. [#750](https://github.com/STORIS/mvom/pull/750)
+- New Increment operation is now supported on numeric fields. The operation will increment the value at the path specified by the amount specified and will return both the original and updated documents. [#750](https://github.com/STORIS/mvom/pull/750), [#757](https://github.com/STORIS/mvom/pull/757), [#758](https://github.com/STORIS/mvom/pull/758)
 - New internal unibasic subroutine `writeRecord` was created to be shared by `save` and `increment` operations for writes to the database. [#756](https://github.com/STORIS/mvom/pull/756)
-- `increment` operation returns both the original and updated document. [#757](https://github.com/STORIS/mvom/pull/757)
-- Exporting the `ModelIncrementResult` type from the main entry point. [#758](https://github.com/STORIS/mvom/pull/758)
 
 ## [3.0.0-rc.4]
 
@@ -501,7 +499,8 @@ We've graduated from Alpha to Beta! Semver has been updated so breaking vs. non-
 
 Initial alpha release of this library! Thanks for using it!
 
-[unreleased]: https://github.com/storis/mvom/compare/3.0.0-rc.4...HEAD
+[unreleased]: https://github.com/storis/mvom/compare/3.0.0-rc.5...HEAD
+[3.0.0-rc.5]: https://github.com/storis/mvom/compare/3.0.0-rc.4...3.0.0-rc.5
 [3.0.0-rc.4]: https://github.com/storis/mvom/compare/3.0.0-rc.3...3.0.0-rc.4
 [3.0.0-rc.3]: https://github.com/storis/mvom/compare/3.0.0-rc.2...3.0.0-rc.3
 [3.0.0-rc.2]: https://github.com/storis/mvom/compare/3.0.0-rc.1...3.0.0-rc.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mvom",
-  "version": "3.0.0-rc.4",
+  "version": "3.0.0-rc.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mvom",
-      "version": "3.0.0-rc.4",
+      "version": "3.0.0-rc.5",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.25.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mvom",
   "private": true,
-  "version": "3.0.0-rc.4",
+  "version": "3.0.0-rc.5",
   "description": "Multivalue Object Mapper",
   "main": "index.js",
   "engines": {

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -40,7 +40,7 @@ const config: Config = {
 					lastVersion: 'current',
 					versions: {
 						current: {
-							label: '3.0.0-rc.4',
+							label: '3.0.0-rc.5',
 						},
 					},
 					remarkPlugins: [[npm2YarnPlugin, { sync: true }]],
@@ -70,7 +70,7 @@ const config: Config = {
 				},
 				{
 					type: 'docsVersion',
-					label: '3.0.0-rc.4',
+					label: '3.0.0-rc.5',
 					position: 'right',
 				},
 				{


### PR DESCRIPTION
This PR makes the necessary changes to release a new version `3.0.0-rc.5`. Included are updates to the following:

- `package.json` and `package-lock.json` versions
- Updates to CHANGELOG describing changes in this release
- Updates to documentation versions