### PR TITLE
Allow for required empty string enumerations

### DIFF
--- a/src/schemaType/StringType.ts
+++ b/src/schemaType/StringType.ts
@@ -52,11 +52,12 @@ class StringType extends BaseScalarType {
 	}
 
 	/** String required validator */
-	protected override validateRequired = (value: unknown): boolean =>
-		!this.required || (value != null && value !== '');
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types -- Use any instead of unknown to avoid type errors in enum validation
+	protected override validateRequired = (value: any): boolean =>
+		!this.required || this.enum?.includes(value) || (value != null && value !== '');
 
 	/** Enum validator */
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Use any instead of unknown to avoid type errors in enum validation
 	private validateEnum = (value: any): boolean =>
 		// skip validation on nullish values because a required validation error, if applicable, is more helpful
 		value == null || this.enum == null || this.enum.includes(value);

--- a/src/schemaType/__tests__/StringType.test.ts
+++ b/src/schemaType/__tests__/StringType.test.ts
@@ -134,6 +134,20 @@ describe('validations', () => {
 			expect(stringType.validate(value)).toContain('Property is required');
 		});
 
+		test('should return error message if required is true, value is empty string, and enumeration does not contain empty string', () => {
+			const definition: SchemaTypeDefinitionString = {
+				type: 'string',
+				path: '2',
+				required: true,
+				enum: ['foo', 'bar'],
+			};
+			const stringType = new StringType(definition);
+
+			const value = '';
+
+			expect(stringType.validate(value)).toContain('Property is required');
+		});
+
 		test('should not return error message if required is true and value is populated with a string', () => {
 			const definition: SchemaTypeDefinitionString = {
 				type: 'string',
@@ -165,6 +179,20 @@ describe('validations', () => {
 				type: 'string',
 				path: '2',
 				required: false,
+			};
+			const stringType = new StringType(definition);
+
+			const value = '';
+
+			expect(stringType.validate(value)).not.toContain('Property is required');
+		});
+
+		test('should not return error message if required is true, value is empty string, and enumeration contains empty string', () => {
+			const definition: SchemaTypeDefinitionString = {
+				type: 'string',
+				path: '2',
+				required: true,
+				enum: ['', 'foo', 'bar'],
 			};
 			const stringType = new StringType(definition);
 


### PR DESCRIPTION
Currently, you cannot have a string schema property which is both required and has an enumeration list containing empty string. Empty strings are considered as failing required validation so even though it is a permissible value as defined by the enumeration it will still trigger a required validation failure. However, on output transformation, if an empty string is in the enumeration list, the output from mvom will be empty string instead of `null`.

This PR modifies the required validation for strings so that if a property is required, it will not be considered an error if the value is present in the enumeration list, regardless of whether or not it is an empty string. This will allow empty strings to be defined for non-nullable fields and align the behavior more closely with the output transformation behavior for enumerations that contain empty strings.