### PR TITLE
Add _id and __v to types for schemaless models

### DIFF
--- a/src/Schema.ts
+++ b/src/Schema.ts
@@ -1,3 +1,4 @@
+import type { RequiredModelMeta } from './compileModel';
 import {
 	BooleanDataTransformer,
 	ISOCalendarDateDataTransformer,
@@ -166,7 +167,7 @@ export type InferDocumentObject<TSchema extends Schema, TConstraint = SchemaType
 
 /** Infer the shape of a `Model` instance based upon the Schema it was instantiated with */
 export type InferModelObject<TSchema extends Schema> = Remap<
-	{ _id: string; __v: string } & InferDocumentObject<TSchema>
+	InferDocumentObject<TSchema> & RequiredModelMeta
 >;
 
 /**

--- a/src/__tests__/compileModel.test.ts
+++ b/src/__tests__/compileModel.test.ts
@@ -1179,9 +1179,15 @@ describe('type inference', () => {
 			const test1: Equals<Result['_raw'], MvRecord> = true;
 			expect(test1).toBe(true);
 
-			// any other property should be unknown
-			const test2: Equals<Result['otherProp'], unknown> = true;
+			const test2: Equals<Result['_id'], string> = true;
 			expect(test2).toBe(true);
+
+			const test3: Equals<Result['__v'], string> = true;
+			expect(test3).toBe(true);
+
+			// any other property should be unknown
+			const test4: Equals<Result['otherProp'], unknown> = true;
+			expect(test4).toBe(true);
 		});
 
 		test('find', () => {
@@ -1192,9 +1198,15 @@ describe('type inference', () => {
 			const test1: Equals<Result['_raw'], MvRecord> = true;
 			expect(test1).toBe(true);
 
-			// any other property should be unknown
-			const test2: Equals<Result['otherProp'], unknown> = true;
+			const test2: Equals<Result['_id'], string> = true;
 			expect(test2).toBe(true);
+
+			const test3: Equals<Result['__v'], string> = true;
+			expect(test3).toBe(true);
+
+			// any other property should be unknown
+			const test4: Equals<Result['otherProp'], unknown> = true;
+			expect(test4).toBe(true);
 		});
 
 		test('findAndCount', () => {
@@ -1205,9 +1217,15 @@ describe('type inference', () => {
 			const test1: Equals<Result['_raw'], MvRecord> = true;
 			expect(test1).toBe(true);
 
-			// any other property should be unknown
-			const test2: Equals<Result['otherProp'], unknown> = true;
+			const test2: Equals<Result['_id'], string> = true;
 			expect(test2).toBe(true);
+
+			const test3: Equals<Result['__v'], string> = true;
+			expect(test3).toBe(true);
+
+			// any other property should be unknown
+			const test4: Equals<Result['otherProp'], unknown> = true;
+			expect(test4).toBe(true);
 		});
 
 		test('findById', () => {
@@ -1218,9 +1236,15 @@ describe('type inference', () => {
 			const test1: Equals<Result['_raw'], MvRecord> = true;
 			expect(test1).toBe(true);
 
-			// any other property should be unknown
-			const test2: Equals<Result['otherProp'], unknown> = true;
+			const test2: Equals<Result['_id'], string> = true;
 			expect(test2).toBe(true);
+
+			const test3: Equals<Result['__v'], string> = true;
+			expect(test3).toBe(true);
+
+			// any other property should be unknown
+			const test4: Equals<Result['otherProp'], unknown> = true;
+			expect(test4).toBe(true);
 		});
 
 		test('findByIds', () => {
@@ -1231,9 +1255,15 @@ describe('type inference', () => {
 			const test1: Equals<Result['_raw'], MvRecord> = true;
 			expect(test1).toBe(true);
 
-			// any other property should be unknown
-			const test2: Equals<Result['otherProp'], unknown> = true;
+			const test2: Equals<Result['_id'], string> = true;
 			expect(test2).toBe(true);
+
+			const test3: Equals<Result['__v'], string> = true;
+			expect(test3).toBe(true);
+
+			// any other property should be unknown
+			const test4: Equals<Result['otherProp'], unknown> = true;
+			expect(test4).toBe(true);
 		});
 
 		test('save', () => {
@@ -1244,9 +1274,15 @@ describe('type inference', () => {
 			const test1: Equals<Result['_raw'], MvRecord> = true;
 			expect(test1).toBe(true);
 
-			// any other property should be unknown
-			const test2: Equals<Result['otherProp'], unknown> = true;
+			const test2: Equals<Result['_id'], string> = true;
 			expect(test2).toBe(true);
+
+			const test3: Equals<Result['__v'], string> = true;
+			expect(test3).toBe(true);
+
+			// any other property should be unknown
+			const test4: Equals<Result['otherProp'], unknown> = true;
+			expect(test4).toBe(true);
 		});
 	});
 });


### PR DESCRIPTION
The output of Model methods for models that are constructed without a schema should have `_id` and `__v` properties as required like models constructed with a schema. In the current state, the `_id` and `__v` properties of models without a schema is optional.

This PR augments the `ModelCompositeValue` type so that it makes the `_id` and `__v` properties as required.