### PR TITLE
Export MvRecord type from index

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -55,4 +55,4 @@ export type {
 	SchemaTypeDefinitionNumber,
 	SchemaTypeDefinitionString,
 } from './schemaType';
-export type { EncryptFn, DecryptFn } from './types';
+export type { EncryptFn, DecryptFn, MvRecord } from './types';


### PR DESCRIPTION
This PR re-exports the `MvRecord` type from the index entry point.