### PR TITLE
Switch the type definition of array schema properties from arrays to readonly tuples

### DIFF
--- a/src/Schema.ts
+++ b/src/Schema.ts
@@ -48,10 +48,10 @@ export type SchemaTypeDefinition =
 	| SchemaTypeDefinitionArray;
 
 type SchemaTypeDefinitionArray =
-	| Schema[]
-	| SchemaTypeDefinitionScalar[]
-	| SchemaTypeDefinitionScalar[][]
-	| SchemaDefinition[];
+	| readonly [Schema]
+	| readonly [SchemaTypeDefinitionScalar]
+	| readonly [[SchemaTypeDefinitionScalar]]
+	| readonly [SchemaDefinition];
 
 // eslint-disable-next-line @typescript-eslint/consistent-indexed-object-style -- Record cannot circularly reference itself so index signature must be used. refer here: https://github.com/microsoft/TypeScript/pull/33050#issuecomment-714348057 for additional information
 export interface SchemaDefinition {
@@ -378,7 +378,7 @@ class Schema<
 			const newKey = prev != null ? `${prev}.${key}` : key;
 
 			if (Array.isArray(value)) {
-				return acc.set(newKey, this.castArray(value, newKey));
+				return acc.set(newKey, this.castArray(value as SchemaTypeDefinitionArray, newKey));
 			}
 
 			if (this.isScalarDefinition(value)) {
@@ -392,7 +392,7 @@ class Schema<
 				return acc.set(newKey, new EmbeddedType(value));
 			}
 
-			const nestedPaths = this.buildPaths(value, newKey);
+			const nestedPaths = this.buildPaths(value as SchemaDefinition, newKey);
 
 			return new Map([...acc, ...nestedPaths]);
 		}, new Map<string, BaseSchemaType>());

--- a/src/__tests__/Schema.test.ts
+++ b/src/__tests__/Schema.test.ts
@@ -36,6 +36,7 @@ describe('constructor', () => {
 	describe('errors', () => {
 		test('should throw InvalidParameterError if array definition contains multiple elements', () => {
 			const definition: SchemaDefinition = {
+				// @ts-expect-error: intentionally passing invalid argument to test
 				prop1: [
 					{ type: 'string', path: '1' },
 					{ type: 'string', path: '2' },
@@ -50,6 +51,7 @@ describe('constructor', () => {
 		test('should throw InvalidParameterError if nested array definition contains multiple elements', () => {
 			const definition: SchemaDefinition = {
 				prop1: [
+					// @ts-expect-error: intentionally passing invalid argument to test
 					[
 						{ type: 'string', path: '1' },
 						{ type: 'string', path: '2' },


### PR DESCRIPTION
This PR modifies the type definitions of "array" schema properties. Previously, these were defined as arrays. However, that is inaccurate as the schema type definitions do not allow specification of arrays of indefinite length -- they only allow arrays of length 1 (i.e. a tuple). The first change in this PR is to adjust these types to more accurately indicate that a 1-length tuple should be used when constructing array definitions.

A second change was also made to these definitions to designate those tuples as `readonly`. This is to offer better support for the use of `as const` when defining objects which are schema definitions. `as const` must be used for schema definitions that are created outside of the schema constructor parameters in order to get proper type inference for the schema definition. Without it, the generic for the schema is either an error or widens to the broad `SchemaDefinition` which cannot provide any actual type information from the schema. However, without allowing `readonly` for these arrays, the `as const` assertion itself would trigger a type error because it marks the tuples as readonly which is in violation of the defined type. By making the tuples `readonly`, a consumer can specify both readonly and writeable arrays in the schema definition, allowing for the proper use of `as const`.