### PR TITLE
Change output of Connection ISO date/time methods to use templated string literals

### DIFF
--- a/src/Connection.ts
+++ b/src/Connection.ts
@@ -44,6 +44,9 @@ import type {
 	DbSubroutineResponseTypes,
 	DbSubroutineResponseTypesMap,
 	DbSubroutineSetupOptions,
+	ISOCalendarDate,
+	ISOCalendarDateTime,
+	ISOTime,
 } from './types';
 
 // #region Types
@@ -327,21 +330,26 @@ class Connection {
 	}
 
 	/** Get the current ISOCalendarDate from the database */
-	public async getDbDate({ requestId }: GetDbDateOptions = {}): Promise<string> {
+	public async getDbDate({ requestId }: GetDbDateOptions = {}): Promise<ISOCalendarDate> {
 		const { timeDrift } = await this.getDbServerInfo({ requestId });
-		return format(addMilliseconds(Date.now(), timeDrift), ISOCalendarDateFormat);
+		return format(addMilliseconds(Date.now(), timeDrift), ISOCalendarDateFormat) as ISOCalendarDate;
 	}
 
 	/** Get the current ISOCalendarDateTime from the database */
-	public async getDbDateTime({ requestId }: GetDbDateTimeOptions = {}): Promise<string> {
+	public async getDbDateTime({
+		requestId,
+	}: GetDbDateTimeOptions = {}): Promise<ISOCalendarDateTime> {
 		const { timeDrift } = await this.getDbServerInfo({ requestId });
-		return format(addMilliseconds(Date.now(), timeDrift), ISOCalendarDateTimeFormat);
+		return format(
+			addMilliseconds(Date.now(), timeDrift),
+			ISOCalendarDateTimeFormat,
+		) as ISOCalendarDateTime;
 	}
 
 	/** Get the current ISOTime from the database */
-	public async getDbTime({ requestId }: GetDbTimeOptions = {}): Promise<string> {
+	public async getDbTime({ requestId }: GetDbTimeOptions = {}): Promise<ISOTime> {
 		const { timeDrift } = await this.getDbServerInfo({ requestId });
-		return format(addMilliseconds(Date.now(), timeDrift), ISOTimeFormat);
+		return format(addMilliseconds(Date.now(), timeDrift), ISOTimeFormat) as ISOTime;
 	}
 
 	/** Get the multivalue database server limits */

--- a/src/Query.ts
+++ b/src/Query.ts
@@ -11,15 +11,19 @@ import type {
 	DictionaryTypeDefinitionNumber,
 	DictionaryTypeDefinitionString,
 	FlattenDocument,
-	ISOCalendarDate,
-	ISOCalendarDateTime,
-	ISOTime,
 	SchemaDefinition,
 	SchemaTypeDefinition,
 } from './Schema';
 import type Schema from './Schema';
 import type { SchemaTypeDefinitionScalar } from './schemaType';
-import type { DbDocument, DbSubroutineInputFind, DbSubroutineSetupOptions } from './types';
+import type {
+	DbDocument,
+	DbSubroutineInputFind,
+	DbSubroutineSetupOptions,
+	ISOCalendarDate,
+	ISOCalendarDateTime,
+	ISOTime,
+} from './types';
 
 // #region Types
 export interface QueryConstructorOptions<TSchema extends Schema | null> {

--- a/src/Schema.ts
+++ b/src/Schema.ts
@@ -36,6 +36,9 @@ import type {
 	DecryptFn,
 	EncryptFn,
 	FlattenObject,
+	ISOCalendarDate,
+	ISOCalendarDateTime,
+	ISOTime,
 	MarkRequired,
 	Remap,
 } from './types';
@@ -110,13 +113,6 @@ interface DictionaryTypeDetail {
 	dictionary: string;
 	dataTransformer: DataTransformer;
 }
-
-/** Format of ISOCalendarDate output */
-export type ISOCalendarDate = `${number}-${number}-${number}`;
-/** Format of ISOTime output */
-export type ISOTime = `${number}:${number}:${number}.${number}`;
-/** Format of ISOCalendarDateTime output */
-export type ISOCalendarDateTime = `${ISOCalendarDate}T${ISOTime}`;
 
 /** Infer whether a schema type definition is required and union the result with null if it is not */
 type InferRequiredType<TScalar, TType> = TScalar extends { required: true } ? TType : TType | null;

--- a/src/__tests__/Document.test.ts
+++ b/src/__tests__/Document.test.ts
@@ -6,9 +6,9 @@ import type {
 } from '../Document';
 import Document from '../Document';
 import { TransformDataError } from '../errors';
-import type { ISOCalendarDate, ISOCalendarDateTime, ISOTime, SchemaDefinition } from '../Schema';
+import type { SchemaDefinition } from '../Schema';
 import Schema from '../Schema';
-import type { Equals, MvRecord } from '../types';
+import type { Equals, ISOCalendarDate, ISOCalendarDateTime, ISOTime, MvRecord } from '../types';
 
 const { am, vm, svm } = mockDelimiters;
 

--- a/src/__tests__/Query.test.ts
+++ b/src/__tests__/Query.test.ts
@@ -5,9 +5,14 @@ import { InvalidParameterError, QueryLimitError } from '../errors';
 import type LogHandler from '../LogHandler';
 import type { Condition, Filter, QueryExecutionOptions, SortCriteria } from '../Query';
 import Query from '../Query';
-import type { ISOCalendarDate, ISOCalendarDateTime, ISOTime } from '../Schema';
 import Schema from '../Schema';
-import type { DbSubroutineOutputFind, Equals } from '../types';
+import type {
+	DbSubroutineOutputFind,
+	Equals,
+	ISOCalendarDate,
+	ISOCalendarDateTime,
+	ISOTime,
+} from '../types';
 
 const connectionMock = mockDeep<Connection>();
 const filename = 'filename';

--- a/src/__tests__/Schema.test.ts
+++ b/src/__tests__/Schema.test.ts
@@ -12,9 +12,6 @@ import type {
 	InferDocumentObject,
 	InferModelObject,
 	InferSchemaPaths,
-	ISOCalendarDate,
-	ISOCalendarDateTime,
-	ISOTime,
 	SchemaDefinition,
 } from '../Schema';
 import Schema from '../Schema';
@@ -30,7 +27,7 @@ import {
 	NumberType,
 	StringType,
 } from '../schemaType';
-import type { Equals } from '../types';
+import type { Equals, ISOCalendarDate, ISOCalendarDateTime, ISOTime } from '../types';
 
 describe('constructor', () => {
 	describe('errors', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,9 +17,6 @@ export {
 	type SchemaDefinition,
 	type DictionariesOption,
 	type SchemaConstructorOptions,
-	type ISOCalendarDate,
-	type ISOCalendarDateTime,
-	type ISOTime,
 	type FlattenDocument,
 	type InferDocumentObject,
 	type InferModelObject,
@@ -55,4 +52,11 @@ export type {
 	SchemaTypeDefinitionNumber,
 	SchemaTypeDefinitionString,
 } from './schemaType';
-export type { EncryptFn, DecryptFn, MvRecord } from './types';
+export type {
+	EncryptFn,
+	DecryptFn,
+	MvRecord,
+	ISOCalendarDate,
+	ISOCalendarDateTime,
+	ISOTime,
+} from './types';

--- a/src/types/Miscellaneous.ts
+++ b/src/types/Miscellaneous.ts
@@ -3,3 +3,10 @@ export type MvDataType = string | null | undefined;
 export type MvAttribute = MvDataType | (MvDataType | MvDataType[])[];
 
 export type MvRecord = MvAttribute[];
+
+/** Format of ISOCalendarDate output */
+export type ISOCalendarDate = `${number}-${number}-${number}`;
+/** Format of ISOTime output */
+export type ISOTime = `${number}:${number}:${number}.${number}`;
+/** Format of ISOCalendarDateTime output */
+export type ISOCalendarDateTime = `${ISOCalendarDate}T${ISOTime}`;


### PR DESCRIPTION
The type inference for schema properties defined with the "ISO" types, `ISOCalendarDate`, `ISOTime`, and `ISOCalendarDateTime` all emit templated string literal types rather than simply strings. However, the `Connection` methods which return the current date, time, and date-time from the database are inconsistently returning a type of "string" from the database. Therefore, if you attempt to get a date, time, or date-time using the `Connection` methods and then supply that value to a schema property defined by one of those types it will cause a type error.

This PR adjusts the `Connection` methods `getDbDate`, `getDbDateTime`, and `getDbTime` to return `ISOCalendarDate`, `ISOCalendarDateTime`, and `ISOTime` types respectively. This makes those methods consistent with the types inferred from schemas.

Since both `Connection` and `Schema` now emit these types, they have been relocated to `types/Miscellaneous`.