### PR TITLE
Fix tests that aren't doing what they should

### DIFF
--- a/src/__tests__/Schema.test.ts
+++ b/src/__tests__/Schema.test.ts
@@ -566,12 +566,12 @@ describe('utility types', () => {
 
 				// required should not be nullable
 				const schema2 = new Schema({
-					isoCalendarDateTimeProp: { type: 'ISOCalendarDateTime', path: '1' },
+					isoCalendarDateTimeProp: { type: 'ISOCalendarDateTime', path: '1', required: true },
 				});
 				const test2: Equals<
 					InferDocumentObject<typeof schema2>,
 					{
-						isoCalendarDateTimeProp: ISOCalendarDateTime | null;
+						isoCalendarDateTimeProp: ISOCalendarDateTime;
 					}
 				> = true;
 				expect(test2).toBe(true);
@@ -965,14 +965,14 @@ describe('utility types', () => {
 
 				// required should not be nullable
 				const schema2 = new Schema({
-					isoCalendarDateTimeProp: { type: 'ISOCalendarDateTime', path: '1' },
+					isoCalendarDateTimeProp: { type: 'ISOCalendarDateTime', path: '1', required: true },
 				});
 				const test2: Equals<
 					InferModelObject<typeof schema2>,
 					{
 						_id: string;
 						__v: string;
-						isoCalendarDateTimeProp: ISOCalendarDateTime | null;
+						isoCalendarDateTimeProp: ISOCalendarDateTime;
 					}
 				> = true;
 				expect(test2).toBe(true);


### PR DESCRIPTION
In the utility type tests within `Schema.test.ts` there is a test for behavior when `ISOCalendarDateTime` is marked `required`. However, the test scenario does not mark it as `required` and therefore the test isn't testing the condition it intended to.

This PR updates the assertion to be working with a `required` schema property.