### PR TITLE
Improve inferred types for _raw property

### DIFF
--- a/src/Document.ts
+++ b/src/Document.ts
@@ -7,9 +7,9 @@ import type { DbServerDelimiters, DeepOptionalNullable, MvRecord } from './types
 
 // #region Types
 /** Type of data property for constructing a document dependent upon the schema */
-export type DocumentData<TSchema extends Schema | null> = TSchema extends Schema
-	? DeepOptionalNullable<InferDocumentObject<TSchema>>
-	: never;
+export type DocumentData<TSchema extends Schema | null> = DeepOptionalNullable<
+	InferDocumentObject<TSchema>
+>;
 
 export interface DocumentConstructorOptions<TSchema extends Schema | null> {
 	data?: DocumentData<TSchema>;
@@ -27,9 +27,8 @@ export interface BuildForeignKeyDefinitionsResult {
  * An intersection type that combines the `Document` class instance with the
  * inferred shape of the document object based on the schema definition.
  */
-export type DocumentCompositeValue<TSchema extends Schema | null> = TSchema extends Schema
-	? Document<TSchema> & InferDocumentObject<TSchema>
-	: Document<TSchema>;
+export type DocumentCompositeValue<TSchema extends Schema | null> = Document<TSchema> &
+	InferDocumentObject<TSchema>;
 // #endregion
 
 /** A document object */

--- a/src/Schema.ts
+++ b/src/Schema.ts
@@ -40,6 +40,7 @@ import type {
 	ISOCalendarDateTime,
 	ISOTime,
 	MarkRequired,
+	MvRecord,
 	Remap,
 } from './types';
 
@@ -152,17 +153,17 @@ type InferSchemaType<TSchemaTypeDefinition, TConstraint> =
  *
  * Allows a constraint to be specified to filter the output to only include properties of a specific type
  */
-export type InferDocumentObject<TSchema extends Schema, TConstraint = SchemaTypeDefinition> =
+export type InferDocumentObject<TSchema extends Schema | null, TConstraint = SchemaTypeDefinition> =
 	TSchema extends Schema<infer TSchemaDefinition>
 		? {
 				[K in keyof TSchemaDefinition as TSchemaDefinition[K] extends TConstraint
 					? K
 					: never]: InferSchemaType<TSchemaDefinition[K], TConstraint>;
 			}
-		: never;
+		: { _raw: MvRecord };
 
 /** Infer the shape of a `Model` instance based upon the Schema it was instantiated with */
-export type InferModelObject<TSchema extends Schema> = Remap<
+export type InferModelObject<TSchema extends Schema | null> = Remap<
 	InferDocumentObject<TSchema> & RequiredModelMeta
 >;
 

--- a/src/__tests__/Document.test.ts
+++ b/src/__tests__/Document.test.ts
@@ -1133,5 +1133,10 @@ describe('utility types', () => {
 			> = true;
 			expect(test1).toBe(true);
 		});
+
+		test('should have a _raw property if schema is null', () => {
+			const test1: Equals<DocumentData<null>, { _raw: MvRecord }> = true;
+			expect(test1).toBe(true);
+		});
 	});
 });

--- a/src/__tests__/Schema.test.ts
+++ b/src/__tests__/Schema.test.ts
@@ -27,7 +27,7 @@ import {
 	NumberType,
 	StringType,
 } from '../schemaType';
-import type { Equals, ISOCalendarDate, ISOCalendarDateTime, ISOTime } from '../types';
+import type { Equals, ISOCalendarDate, ISOCalendarDateTime, ISOTime, MvRecord } from '../types';
 
 describe('constructor', () => {
 	describe('errors', () => {
@@ -828,6 +828,13 @@ describe('utility types', () => {
 				expect(test1).toBe(true);
 			});
 		});
+
+		describe('null schema', () => {
+			test('should have the _raw property', () => {
+				const test1: Equals<InferDocumentObject<null>, { _raw: MvRecord }> = true;
+				expect(test1).toBe(true);
+			});
+		});
 	});
 
 	describe('InferModelObject', () => {
@@ -837,7 +844,7 @@ describe('utility types', () => {
 				const schema1 = new Schema({ stringProp: { type: 'string', path: '1' } });
 				const test1: Equals<
 					InferModelObject<typeof schema1>,
-					{ _id: string; __v: string; stringProp: string | null }
+					{ _id: string; __v: string; _originalRecordString: string; stringProp: string | null }
 				> = true;
 				expect(test1).toBe(true);
 
@@ -845,7 +852,7 @@ describe('utility types', () => {
 				const schema2 = new Schema({ stringProp: { type: 'string', path: '1', required: true } });
 				const test2: Equals<
 					InferModelObject<typeof schema2>,
-					{ _id: string; __v: string; stringProp: string }
+					{ _id: string; __v: string; _originalRecordString: string; stringProp: string }
 				> = true;
 				expect(test2).toBe(true);
 
@@ -855,7 +862,12 @@ describe('utility types', () => {
 				});
 				const test3: Equals<
 					InferModelObject<typeof schema3>,
-					{ _id: string; __v: string; stringProp: 'foo' | 'bar' | null }
+					{
+						_id: string;
+						__v: string;
+						_originalRecordString: string;
+						stringProp: 'foo' | 'bar' | null;
+					}
 				> = true;
 				expect(test3).toBe(true);
 
@@ -865,7 +877,7 @@ describe('utility types', () => {
 				});
 				const test4: Equals<
 					InferModelObject<typeof schema4>,
-					{ _id: string; __v: string; stringProp: 'foo' | 'bar' }
+					{ _id: string; __v: string; _originalRecordString: string; stringProp: 'foo' | 'bar' }
 				> = true;
 				expect(test4).toBe(true);
 			});
@@ -875,7 +887,7 @@ describe('utility types', () => {
 				const schema1 = new Schema({ numberProp: { type: 'number', path: '1' } });
 				const test1: Equals<
 					InferModelObject<typeof schema1>,
-					{ _id: string; __v: string; numberProp: number | null }
+					{ _id: string; __v: string; _originalRecordString: string; numberProp: number | null }
 				> = true;
 				expect(test1).toBe(true);
 
@@ -883,7 +895,7 @@ describe('utility types', () => {
 				const schema2 = new Schema({ numberProp: { type: 'number', path: '1', required: true } });
 				const test2: Equals<
 					InferModelObject<typeof schema2>,
-					{ _id: string; __v: string; numberProp: number }
+					{ _id: string; __v: string; _originalRecordString: string; numberProp: number }
 				> = true;
 				expect(test2).toBe(true);
 			});
@@ -893,7 +905,7 @@ describe('utility types', () => {
 				const schema1 = new Schema({ booleanProp: { type: 'boolean', path: '1' } });
 				const test1: Equals<
 					InferModelObject<typeof schema1>,
-					{ _id: string; __v: string; booleanProp: boolean | null }
+					{ _id: string; __v: string; _originalRecordString: string; booleanProp: boolean | null }
 				> = true;
 				expect(test1).toBe(true);
 
@@ -901,7 +913,7 @@ describe('utility types', () => {
 				const schema2 = new Schema({ booleanProp: { type: 'boolean', path: '1', required: true } });
 				const test2: Equals<
 					InferModelObject<typeof schema2>,
-					{ _id: string; __v: string; booleanProp: boolean }
+					{ _id: string; __v: string; _originalRecordString: string; booleanProp: boolean }
 				> = true;
 				expect(test2).toBe(true);
 			});
@@ -911,7 +923,12 @@ describe('utility types', () => {
 				const schema1 = new Schema({ isoCalendarDateProp: { type: 'ISOCalendarDate', path: '1' } });
 				const test1: Equals<
 					InferModelObject<typeof schema1>,
-					{ _id: string; __v: string; isoCalendarDateProp: ISOCalendarDate | null }
+					{
+						_id: string;
+						__v: string;
+						_originalRecordString: string;
+						isoCalendarDateProp: ISOCalendarDate | null;
+					}
 				> = true;
 				expect(test1).toBe(true);
 
@@ -921,7 +938,12 @@ describe('utility types', () => {
 				});
 				const test2: Equals<
 					InferModelObject<typeof schema2>,
-					{ _id: string; __v: string; isoCalendarDateProp: ISOCalendarDate }
+					{
+						_id: string;
+						__v: string;
+						_originalRecordString: string;
+						isoCalendarDateProp: ISOCalendarDate;
+					}
 				> = true;
 				expect(test2).toBe(true);
 			});
@@ -931,11 +953,7 @@ describe('utility types', () => {
 				const schema1 = new Schema({ isoTimeProp: { type: 'ISOTime', path: '1' } });
 				const test1: Equals<
 					InferModelObject<typeof schema1>,
-					{
-						_id: string;
-						__v: string;
-						isoTimeProp: ISOTime | null;
-					}
+					{ _id: string; __v: string; _originalRecordString: string; isoTimeProp: ISOTime | null }
 				> = true;
 				expect(test1).toBe(true);
 
@@ -943,7 +961,7 @@ describe('utility types', () => {
 				const schema2 = new Schema({ isoTimeProp: { type: 'ISOTime', path: '1', required: true } });
 				const test2: Equals<
 					InferModelObject<typeof schema2>,
-					{ _id: string; __v: string; isoTimeProp: ISOTime }
+					{ _id: string; __v: string; _originalRecordString: string; isoTimeProp: ISOTime }
 				> = true;
 				expect(test2).toBe(true);
 			});
@@ -958,6 +976,7 @@ describe('utility types', () => {
 					{
 						_id: string;
 						__v: string;
+						_originalRecordString: string;
 						isoCalendarDateTimeProp: ISOCalendarDateTime | null;
 					}
 				> = true;
@@ -972,6 +991,7 @@ describe('utility types', () => {
 					{
 						_id: string;
 						__v: string;
+						_originalRecordString: string;
 						isoCalendarDateTimeProp: ISOCalendarDateTime;
 					}
 				> = true;
@@ -987,7 +1007,12 @@ describe('utility types', () => {
 				});
 				const test1: Equals<
 					InferModelObject<typeof schema1>,
-					{ _id: string; __v: string; embeddedProp: { innerEmbeddedProp: string | null } }
+					{
+						_id: string;
+						__v: string;
+						_originalRecordString: string;
+						embeddedProp: { innerEmbeddedProp: string | null };
+					}
 				> = true;
 				expect(test1).toBe(true);
 
@@ -999,7 +1024,12 @@ describe('utility types', () => {
 				});
 				const test2: Equals<
 					InferModelObject<typeof schema2>,
-					{ _id: string; __v: string; embeddedProp: { innerEmbeddedProp: string } }
+					{
+						_id: string;
+						__v: string;
+						_originalRecordString: string;
+						embeddedProp: { innerEmbeddedProp: string };
+					}
 				> = true;
 				expect(test2).toBe(true);
 			});
@@ -1011,7 +1041,12 @@ describe('utility types', () => {
 				});
 				const test1: Equals<
 					InferModelObject<typeof schema1>,
-					{ _id: string; __v: string; embeddedProp: { innerEmbeddedProp: string | null } }
+					{
+						_id: string;
+						__v: string;
+						_originalRecordString: string;
+						embeddedProp: { innerEmbeddedProp: string | null };
+					}
 				> = true;
 				expect(test1).toBe(true);
 
@@ -1021,7 +1056,12 @@ describe('utility types', () => {
 				});
 				const test2: Equals<
 					InferModelObject<typeof schema2>,
-					{ _id: string; __v: string; embeddedProp: { innerEmbeddedProp: string } }
+					{
+						_id: string;
+						__v: string;
+						_originalRecordString: string;
+						embeddedProp: { innerEmbeddedProp: string };
+					}
 				> = true;
 				expect(test2).toBe(true);
 			});
@@ -1040,6 +1080,7 @@ describe('utility types', () => {
 					{
 						_id: string;
 						__v: string;
+						_originalRecordString: string;
 						embeddedProp: { innerEmbeddedProp: { deepEmbeddedProp: string | null } };
 					}
 				> = true;
@@ -1058,6 +1099,7 @@ describe('utility types', () => {
 					{
 						_id: string;
 						__v: string;
+						_originalRecordString: string;
 						embeddedProp: { innerEmbeddedProp: { deepEmbeddedProp: string } };
 					}
 				> = true;
@@ -1071,7 +1113,7 @@ describe('utility types', () => {
 				const schema1 = new Schema({ arrayProp: [{ type: 'string', path: '1' }] });
 				const test1: Equals<
 					InferModelObject<typeof schema1>,
-					{ _id: string; __v: string; arrayProp: (string | null)[] }
+					{ _id: string; __v: string; _originalRecordString: string; arrayProp: (string | null)[] }
 				> = true;
 				expect(test1).toBe(true);
 
@@ -1079,7 +1121,7 @@ describe('utility types', () => {
 				const schema2 = new Schema({ arrayProp: [{ type: 'string', path: '1', required: true }] });
 				const test2: Equals<
 					InferModelObject<typeof schema2>,
-					{ _id: string; __v: string; arrayProp: string[] }
+					{ _id: string; __v: string; _originalRecordString: string; arrayProp: string[] }
 				> = true;
 				expect(test2).toBe(true);
 			});
@@ -1089,7 +1131,12 @@ describe('utility types', () => {
 				const schema1 = new Schema({ nestedArrayProp: [[{ type: 'string', path: '1' }]] });
 				const test1: Equals<
 					InferModelObject<typeof schema1>,
-					{ _id: string; __v: string; nestedArrayProp: (string | null)[][] }
+					{
+						_id: string;
+						__v: string;
+						_originalRecordString: string;
+						nestedArrayProp: (string | null)[][];
+					}
 				> = true;
 				expect(test1).toBe(true);
 
@@ -1099,7 +1146,7 @@ describe('utility types', () => {
 				});
 				const test2: Equals<
 					InferModelObject<typeof schema2>,
-					{ _id: string; __v: string; nestedArrayProp: string[][] }
+					{ _id: string; __v: string; _originalRecordString: string; nestedArrayProp: string[][] }
 				> = true;
 				expect(test2).toBe(true);
 			});
@@ -1119,6 +1166,7 @@ describe('utility types', () => {
 					{
 						_id: string;
 						__v: string;
+						_originalRecordString: string;
 						documentArrayProp: { docStringProp: string | null; docNumberProp: number | null }[];
 					}
 				> = true;
@@ -1138,6 +1186,7 @@ describe('utility types', () => {
 					{
 						_id: string;
 						__v: string;
+						_originalRecordString: string;
 						documentArrayProp: { docStringProp: string; docNumberProp: number | null }[];
 					}
 				> = true;
@@ -1151,7 +1200,12 @@ describe('utility types', () => {
 				});
 				const test1: Equals<
 					InferModelObject<typeof schema1>,
-					{ _id: string; __v: string; documentArraySchemaProp: { docStringProp: string | null }[] }
+					{
+						_id: string;
+						__v: string;
+						_originalRecordString: string;
+						documentArraySchemaProp: { docStringProp: string | null }[];
+					}
 				> = true;
 				expect(test1).toBe(true);
 
@@ -1163,7 +1217,12 @@ describe('utility types', () => {
 				});
 				const test2: Equals<
 					InferModelObject<typeof schema2>,
-					{ _id: string; __v: string; documentArraySchemaProp: { docStringProp: string }[] }
+					{
+						_id: string;
+						__v: string;
+						_originalRecordString: string;
+						documentArraySchemaProp: { docStringProp: string }[];
+					}
 				> = true;
 				expect(test2).toBe(true);
 			});
@@ -1223,6 +1282,7 @@ describe('utility types', () => {
 					{
 						_id: string;
 						__v: string;
+						_originalRecordString: string;
 						booleanOptional: boolean | null;
 						booleanRequired: boolean;
 						stringOptional: string | null;
@@ -1246,6 +1306,16 @@ describe('utility types', () => {
 						documentArraySchemaOptional: { docStringProp: string | null }[];
 						documentArraySchemaRequired: { docStringProp: string }[];
 					}
+				> = true;
+				expect(test1).toBe(true);
+			});
+		});
+
+		describe('null schema', () => {
+			test('should have the _raw property', () => {
+				const test1: Equals<
+					InferModelObject<null>,
+					{ _id: string; __v: string; _originalRecordString: string; _raw: MvRecord }
 				> = true;
 				expect(test1).toBe(true);
 			});

--- a/src/__tests__/Schema.test.ts
+++ b/src/__tests__/Schema.test.ts
@@ -844,7 +844,7 @@ describe('utility types', () => {
 				const schema1 = new Schema({ stringProp: { type: 'string', path: '1' } });
 				const test1: Equals<
 					InferModelObject<typeof schema1>,
-					{ _id: string; __v: string; _originalRecordString: string; stringProp: string | null }
+					{ _id: string; __v: string; stringProp: string | null }
 				> = true;
 				expect(test1).toBe(true);
 
@@ -852,7 +852,7 @@ describe('utility types', () => {
 				const schema2 = new Schema({ stringProp: { type: 'string', path: '1', required: true } });
 				const test2: Equals<
 					InferModelObject<typeof schema2>,
-					{ _id: string; __v: string; _originalRecordString: string; stringProp: string }
+					{ _id: string; __v: string; stringProp: string }
 				> = true;
 				expect(test2).toBe(true);
 
@@ -862,12 +862,7 @@ describe('utility types', () => {
 				});
 				const test3: Equals<
 					InferModelObject<typeof schema3>,
-					{
-						_id: string;
-						__v: string;
-						_originalRecordString: string;
-						stringProp: 'foo' | 'bar' | null;
-					}
+					{ _id: string; __v: string; stringProp: 'foo' | 'bar' | null }
 				> = true;
 				expect(test3).toBe(true);
 
@@ -877,7 +872,7 @@ describe('utility types', () => {
 				});
 				const test4: Equals<
 					InferModelObject<typeof schema4>,
-					{ _id: string; __v: string; _originalRecordString: string; stringProp: 'foo' | 'bar' }
+					{ _id: string; __v: string; stringProp: 'foo' | 'bar' }
 				> = true;
 				expect(test4).toBe(true);
 			});
@@ -887,7 +882,7 @@ describe('utility types', () => {
 				const schema1 = new Schema({ numberProp: { type: 'number', path: '1' } });
 				const test1: Equals<
 					InferModelObject<typeof schema1>,
-					{ _id: string; __v: string; _originalRecordString: string; numberProp: number | null }
+					{ _id: string; __v: string; numberProp: number | null }
 				> = true;
 				expect(test1).toBe(true);
 
@@ -895,7 +890,7 @@ describe('utility types', () => {
 				const schema2 = new Schema({ numberProp: { type: 'number', path: '1', required: true } });
 				const test2: Equals<
 					InferModelObject<typeof schema2>,
-					{ _id: string; __v: string; _originalRecordString: string; numberProp: number }
+					{ _id: string; __v: string; numberProp: number }
 				> = true;
 				expect(test2).toBe(true);
 			});
@@ -905,7 +900,7 @@ describe('utility types', () => {
 				const schema1 = new Schema({ booleanProp: { type: 'boolean', path: '1' } });
 				const test1: Equals<
 					InferModelObject<typeof schema1>,
-					{ _id: string; __v: string; _originalRecordString: string; booleanProp: boolean | null }
+					{ _id: string; __v: string; booleanProp: boolean | null }
 				> = true;
 				expect(test1).toBe(true);
 
@@ -913,7 +908,7 @@ describe('utility types', () => {
 				const schema2 = new Schema({ booleanProp: { type: 'boolean', path: '1', required: true } });
 				const test2: Equals<
 					InferModelObject<typeof schema2>,
-					{ _id: string; __v: string; _originalRecordString: string; booleanProp: boolean }
+					{ _id: string; __v: string; booleanProp: boolean }
 				> = true;
 				expect(test2).toBe(true);
 			});
@@ -923,12 +918,7 @@ describe('utility types', () => {
 				const schema1 = new Schema({ isoCalendarDateProp: { type: 'ISOCalendarDate', path: '1' } });
 				const test1: Equals<
 					InferModelObject<typeof schema1>,
-					{
-						_id: string;
-						__v: string;
-						_originalRecordString: string;
-						isoCalendarDateProp: ISOCalendarDate | null;
-					}
+					{ _id: string; __v: string; isoCalendarDateProp: ISOCalendarDate | null }
 				> = true;
 				expect(test1).toBe(true);
 
@@ -938,12 +928,7 @@ describe('utility types', () => {
 				});
 				const test2: Equals<
 					InferModelObject<typeof schema2>,
-					{
-						_id: string;
-						__v: string;
-						_originalRecordString: string;
-						isoCalendarDateProp: ISOCalendarDate;
-					}
+					{ _id: string; __v: string; isoCalendarDateProp: ISOCalendarDate }
 				> = true;
 				expect(test2).toBe(true);
 			});
@@ -953,7 +938,7 @@ describe('utility types', () => {
 				const schema1 = new Schema({ isoTimeProp: { type: 'ISOTime', path: '1' } });
 				const test1: Equals<
 					InferModelObject<typeof schema1>,
-					{ _id: string; __v: string; _originalRecordString: string; isoTimeProp: ISOTime | null }
+					{ _id: string; __v: string; isoTimeProp: ISOTime | null }
 				> = true;
 				expect(test1).toBe(true);
 
@@ -961,7 +946,7 @@ describe('utility types', () => {
 				const schema2 = new Schema({ isoTimeProp: { type: 'ISOTime', path: '1', required: true } });
 				const test2: Equals<
 					InferModelObject<typeof schema2>,
-					{ _id: string; __v: string; _originalRecordString: string; isoTimeProp: ISOTime }
+					{ _id: string; __v: string; isoTimeProp: ISOTime }
 				> = true;
 				expect(test2).toBe(true);
 			});
@@ -976,7 +961,6 @@ describe('utility types', () => {
 					{
 						_id: string;
 						__v: string;
-						_originalRecordString: string;
 						isoCalendarDateTimeProp: ISOCalendarDateTime | null;
 					}
 				> = true;
@@ -991,7 +975,6 @@ describe('utility types', () => {
 					{
 						_id: string;
 						__v: string;
-						_originalRecordString: string;
 						isoCalendarDateTimeProp: ISOCalendarDateTime;
 					}
 				> = true;
@@ -1007,12 +990,7 @@ describe('utility types', () => {
 				});
 				const test1: Equals<
 					InferModelObject<typeof schema1>,
-					{
-						_id: string;
-						__v: string;
-						_originalRecordString: string;
-						embeddedProp: { innerEmbeddedProp: string | null };
-					}
+					{ _id: string; __v: string; embeddedProp: { innerEmbeddedProp: string | null } }
 				> = true;
 				expect(test1).toBe(true);
 
@@ -1024,12 +1002,7 @@ describe('utility types', () => {
 				});
 				const test2: Equals<
 					InferModelObject<typeof schema2>,
-					{
-						_id: string;
-						__v: string;
-						_originalRecordString: string;
-						embeddedProp: { innerEmbeddedProp: string };
-					}
+					{ _id: string; __v: string; embeddedProp: { innerEmbeddedProp: string } }
 				> = true;
 				expect(test2).toBe(true);
 			});
@@ -1041,12 +1014,7 @@ describe('utility types', () => {
 				});
 				const test1: Equals<
 					InferModelObject<typeof schema1>,
-					{
-						_id: string;
-						__v: string;
-						_originalRecordString: string;
-						embeddedProp: { innerEmbeddedProp: string | null };
-					}
+					{ _id: string; __v: string; embeddedProp: { innerEmbeddedProp: string | null } }
 				> = true;
 				expect(test1).toBe(true);
 
@@ -1056,12 +1024,7 @@ describe('utility types', () => {
 				});
 				const test2: Equals<
 					InferModelObject<typeof schema2>,
-					{
-						_id: string;
-						__v: string;
-						_originalRecordString: string;
-						embeddedProp: { innerEmbeddedProp: string };
-					}
+					{ _id: string; __v: string; embeddedProp: { innerEmbeddedProp: string } }
 				> = true;
 				expect(test2).toBe(true);
 			});
@@ -1080,7 +1043,6 @@ describe('utility types', () => {
 					{
 						_id: string;
 						__v: string;
-						_originalRecordString: string;
 						embeddedProp: { innerEmbeddedProp: { deepEmbeddedProp: string | null } };
 					}
 				> = true;
@@ -1099,7 +1061,6 @@ describe('utility types', () => {
 					{
 						_id: string;
 						__v: string;
-						_originalRecordString: string;
 						embeddedProp: { innerEmbeddedProp: { deepEmbeddedProp: string } };
 					}
 				> = true;
@@ -1113,7 +1074,7 @@ describe('utility types', () => {
 				const schema1 = new Schema({ arrayProp: [{ type: 'string', path: '1' }] });
 				const test1: Equals<
 					InferModelObject<typeof schema1>,
-					{ _id: string; __v: string; _originalRecordString: string; arrayProp: (string | null)[] }
+					{ _id: string; __v: string; arrayProp: (string | null)[] }
 				> = true;
 				expect(test1).toBe(true);
 
@@ -1121,7 +1082,7 @@ describe('utility types', () => {
 				const schema2 = new Schema({ arrayProp: [{ type: 'string', path: '1', required: true }] });
 				const test2: Equals<
 					InferModelObject<typeof schema2>,
-					{ _id: string; __v: string; _originalRecordString: string; arrayProp: string[] }
+					{ _id: string; __v: string; arrayProp: string[] }
 				> = true;
 				expect(test2).toBe(true);
 			});
@@ -1131,12 +1092,7 @@ describe('utility types', () => {
 				const schema1 = new Schema({ nestedArrayProp: [[{ type: 'string', path: '1' }]] });
 				const test1: Equals<
 					InferModelObject<typeof schema1>,
-					{
-						_id: string;
-						__v: string;
-						_originalRecordString: string;
-						nestedArrayProp: (string | null)[][];
-					}
+					{ _id: string; __v: string; nestedArrayProp: (string | null)[][] }
 				> = true;
 				expect(test1).toBe(true);
 
@@ -1146,7 +1102,7 @@ describe('utility types', () => {
 				});
 				const test2: Equals<
 					InferModelObject<typeof schema2>,
-					{ _id: string; __v: string; _originalRecordString: string; nestedArrayProp: string[][] }
+					{ _id: string; __v: string; nestedArrayProp: string[][] }
 				> = true;
 				expect(test2).toBe(true);
 			});
@@ -1166,7 +1122,6 @@ describe('utility types', () => {
 					{
 						_id: string;
 						__v: string;
-						_originalRecordString: string;
 						documentArrayProp: { docStringProp: string | null; docNumberProp: number | null }[];
 					}
 				> = true;
@@ -1186,7 +1141,6 @@ describe('utility types', () => {
 					{
 						_id: string;
 						__v: string;
-						_originalRecordString: string;
 						documentArrayProp: { docStringProp: string; docNumberProp: number | null }[];
 					}
 				> = true;
@@ -1200,12 +1154,7 @@ describe('utility types', () => {
 				});
 				const test1: Equals<
 					InferModelObject<typeof schema1>,
-					{
-						_id: string;
-						__v: string;
-						_originalRecordString: string;
-						documentArraySchemaProp: { docStringProp: string | null }[];
-					}
+					{ _id: string; __v: string; documentArraySchemaProp: { docStringProp: string | null }[] }
 				> = true;
 				expect(test1).toBe(true);
 
@@ -1217,12 +1166,7 @@ describe('utility types', () => {
 				});
 				const test2: Equals<
 					InferModelObject<typeof schema2>,
-					{
-						_id: string;
-						__v: string;
-						_originalRecordString: string;
-						documentArraySchemaProp: { docStringProp: string }[];
-					}
+					{ _id: string; __v: string; documentArraySchemaProp: { docStringProp: string }[] }
 				> = true;
 				expect(test2).toBe(true);
 			});
@@ -1282,7 +1226,6 @@ describe('utility types', () => {
 					{
 						_id: string;
 						__v: string;
-						_originalRecordString: string;
 						booleanOptional: boolean | null;
 						booleanRequired: boolean;
 						stringOptional: string | null;
@@ -1315,7 +1258,7 @@ describe('utility types', () => {
 			test('should have the _raw property', () => {
 				const test1: Equals<
 					InferModelObject<null>,
-					{ _id: string; __v: string; _originalRecordString: string; _raw: MvRecord }
+					{ _id: string; __v: string; _raw: MvRecord }
 				> = true;
 				expect(test1).toBe(true);
 			});

--- a/src/compileModel.ts
+++ b/src/compileModel.ts
@@ -29,11 +29,11 @@ export type ModelConstructor<TSchema extends Schema | null> = ReturnType<
 
 export type Model<TSchema extends Schema | null> = InstanceType<ModelConstructor<TSchema>>;
 
-/** Used as an intersection type to make _id & __v properties required */
-export interface RequiredModelMeta {
-	_id: string;
-	__v: string;
-}
+type RequiredModelMetaProperties = '_id' | '__v' | '_originalRecordString';
+/** Used as an intersection type to make specific model properties required */
+export type RequiredModelMeta = {
+	[K in RequiredModelMetaProperties]: NonNullable<Model<Schema>[K]>;
+};
 
 /**
  * An intersection type that combines the `Model` class instance with the

--- a/src/compileModel.ts
+++ b/src/compileModel.ts
@@ -40,7 +40,7 @@ export type RequiredModelMeta = {
  * inferred shape of the model object based on the schema definition.
  */
 export type ModelCompositeValue<TSchema extends Schema | null> = Remap<
-	Model<TSchema> & (TSchema extends Schema ? InferModelObject<TSchema> : RequiredModelMeta)
+	Model<TSchema> & InferModelObject<TSchema>
 >;
 
 export interface ModelFindAndCountResult<TSchema extends Schema | null> {

--- a/src/compileModel.ts
+++ b/src/compileModel.ts
@@ -29,7 +29,7 @@ export type ModelConstructor<TSchema extends Schema | null> = ReturnType<
 
 export type Model<TSchema extends Schema | null> = InstanceType<ModelConstructor<TSchema>>;
 
-type RequiredModelMetaProperties = '_id' | '__v' | '_originalRecordString';
+type RequiredModelMetaProperties = '_id' | '__v';
 /** Used as an intersection type to make specific model properties required */
 export type RequiredModelMeta = {
 	[K in RequiredModelMetaProperties]: NonNullable<Model<Schema>[K]>;


### PR DESCRIPTION
This PR makes improvements regarding the `_raw` property of `Document` instances (which also impacts `Model` since it extends `Document`).

The following changes are included:
- `DocumentData` will now include the `_raw` property if the schema is null
- `DocumentCompositeValue` will now include the `_raw` property if the schema is null
- `InferDocumentObject` now accepts a `null` schema in its generic. If the schema is `null` then the `_raw` property will be included on the inferred output
- `InferModelObject` now accepts a `null` schema in its generic.  If the schema is `null` then the `_raw` property will be included on the inferred output