### PR TITLE
Prepare for version 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.1.0]
+
+- Allow equality, inequality, in, and not in query operators to accept null conditional values ([#854](https://github.com/STORIS/mvom/pull/854))
+
 ## [3.0.1]
 
-- Improve inferred types for \_raw property ([#820](https://github.com/STORIS/mvom/pull/820))
+- Improve inferred types for `_raw` property ([#820](https://github.com/STORIS/mvom/pull/820))
 
 ## [3.0.0]
 
@@ -521,7 +525,8 @@ We've graduated from Alpha to Beta! Semver has been updated so breaking vs. non-
 
 Initial alpha release of this library! Thanks for using it!
 
-[unreleased]: https://github.com/storis/mvom/compare/3.0.1...HEAD
+[unreleased]: https://github.com/storis/mvom/compare/3.1.0...HEAD
+[3.1.0]: https://github.com/storis/mvom/compare/3.0.1...3.1.0
 [3.0.1]: https://github.com/storis/mvom/compare/3.0.0...3.0.1
 [3.0.0]: https://github.com/storis/mvom/compare/3.0.0-rc.6...3.0.0
 [3.0.0-rc.6]: https://github.com/storis/mvom/compare/3.0.0-rc.5...3.0.0-rc.6

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mvom",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mvom",
-      "version": "3.0.1",
+      "version": "3.1.0",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.26.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mvom",
   "private": true,
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "Multivalue Object Mapper",
   "main": "index.js",
   "engines": {

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -40,7 +40,7 @@ const config: Config = {
 					lastVersion: 'current',
 					versions: {
 						current: {
-							label: '3.0.1',
+							label: '3.1.0',
 						},
 					},
 					remarkPlugins: [[npm2YarnPlugin, { sync: true }]],
@@ -70,7 +70,7 @@ const config: Config = {
 				},
 				{
 					type: 'docsVersion',
-					label: '3.0.1',
+					label: '3.1.0',
 					position: 'right',
 				},
 				{


### PR DESCRIPTION
This PR makes the necessary changes to release a new version `3.1.0`. Included are updates to the following:

- `package.json` and `package-lock.json` versions
- Updates to `CHANGELOG` describing changes in this release
- Updates to documentation versions