### PR TITLE
Fix type issue with filter/sort and arrays

### DIFF
--- a/src/Document.ts
+++ b/src/Document.ts
@@ -147,7 +147,10 @@ class Document<TSchema extends Schema | null> {
 				);
 	}
 
-	/** Build a list of foreign key definitions to be used by the database for foreign key validation */
+	/**
+	 * Build a list of foreign key definitions to be used by the database for foreign key validation
+	 * TODO: Foreign keys are a Model concept and not a Document concept. Relocate this logic.
+	 */
 	public buildForeignKeyDefinitions(): BuildForeignKeyDefinitionsResult[] {
 		if (this.#schema === null) {
 			return [];
@@ -206,6 +209,7 @@ class Document<TSchema extends Schema | null> {
 		const documentErrors = new Map<string, string[]>();
 
 		if (this.#schema !== null) {
+			// TODO: _id is a Model concept and not a Document concept. Relocate this logic.
 			if (
 				typeof this._id === 'string' &&
 				this.#schema.idMatch != null &&

--- a/src/Schema.ts
+++ b/src/Schema.ts
@@ -126,6 +126,22 @@ type InferRequiredType<TScalar, TType> = TScalar extends { required: true } ? TT
 type InferStringType<TString extends SchemaTypeDefinitionString> =
 	TString['enum'] extends readonly (infer E)[] ? E : string;
 
+/**
+ * Infer the output type of an array schema definition
+ *
+ * Allows a constraint to be specified to filter the output to only include scalar arrays of a specific type
+ */
+type InferArraySchemaType<
+	TSchemaTypeDefinition extends SchemaTypeDefinitionArray,
+	TConstraint,
+> = TSchemaTypeDefinition extends [infer TArrayDefinition]
+	? TArrayDefinition extends SchemaTypeDefinitionScalar
+		? TArrayDefinition extends TConstraint
+			? InferSchemaType<TArrayDefinition, TConstraint>[]
+			: never
+		: InferSchemaType<TArrayDefinition, TConstraint>[]
+	: never;
+
 /** Infer the output type of a schema type definition */
 type InferSchemaType<TSchemaTypeDefinition, TConstraint> =
 	TSchemaTypeDefinition extends SchemaTypeDefinitionBoolean
@@ -143,7 +159,7 @@ type InferSchemaType<TSchemaTypeDefinition, TConstraint> =
 							: TSchemaTypeDefinition extends Schema<infer TSubSchemaDefinition>
 								? InferDocumentObject<Schema<TSubSchemaDefinition>, TConstraint>
 								: TSchemaTypeDefinition extends SchemaTypeDefinitionArray
-									? InferSchemaType<TSchemaTypeDefinition[0], TConstraint>[]
+									? InferArraySchemaType<TSchemaTypeDefinition, TConstraint>
 									: TSchemaTypeDefinition extends SchemaDefinition
 										? InferDocumentObject<Schema<TSchemaTypeDefinition>, TConstraint>
 										: never;

--- a/src/__tests__/Document.test.ts
+++ b/src/__tests__/Document.test.ts
@@ -73,10 +73,10 @@ describe('constructor', () => {
 
 describe('createSubdocumentFromRecord', () => {
 	test('should create a new subdocument from the provided record', () => {
-		const definition: SchemaDefinition = {
+		const definition = {
 			prop1: { type: 'string', path: '3' },
 			prop2: { type: 'number', path: '4', dbDecimals: 2 },
-		};
+		} satisfies SchemaDefinition;
 		const schema = new Schema(definition);
 
 		const document = Document.createSubdocumentFromRecord(schema, [
@@ -91,9 +91,9 @@ describe('createSubdocumentFromRecord', () => {
 	});
 
 	test('should create a new subdocument from the provided record with array schema properties', () => {
-		const definition: SchemaDefinition = {
+		const definition = {
 			arrayProp: [{ type: 'string', path: '3' }],
-		};
+		} satisfies SchemaDefinition;
 		const schema = new Schema(definition);
 
 		const document = Document.createSubdocumentFromRecord(schema, [
@@ -108,9 +108,9 @@ describe('createSubdocumentFromRecord', () => {
 	});
 
 	test('should create a new subdocument from the provided record with array schema properties and sparse arrays', () => {
-		const definition: SchemaDefinition = {
+		const definition = {
 			arrayProp: [{ type: 'string', path: '3' }],
-		};
+		} satisfies SchemaDefinition;
 		const schema = new Schema(definition);
 
 		const document = Document.createSubdocumentFromRecord(schema, [
@@ -125,9 +125,9 @@ describe('createSubdocumentFromRecord', () => {
 	});
 
 	test('should create a new subdocument from the provided record with nested array schema properties', () => {
-		const definition: SchemaDefinition = {
+		const definition = {
 			nestedArrayProp: [[{ type: 'string', path: '3' }]],
-		};
+		} satisfies SchemaDefinition;
 		const schema = new Schema(definition);
 
 		const document = Document.createSubdocumentFromRecord(schema, [
@@ -148,9 +148,9 @@ describe('createSubdocumentFromRecord', () => {
 	});
 
 	test('should create a new subdocument from the provided record with nested array schema properties and sparse arrays', () => {
-		const definition: SchemaDefinition = {
+		const definition = {
 			nestedArrayProp: [[{ type: 'string', path: '3' }]],
-		};
+		} satisfies SchemaDefinition;
 		const schema = new Schema(definition);
 
 		const document = Document.createSubdocumentFromRecord(schema, [
@@ -171,7 +171,7 @@ describe('createSubdocumentFromRecord', () => {
 	});
 
 	test('should create a new subdocument with a subdocument array from the provided record', () => {
-		const definition: SchemaDefinition = {
+		const definition = {
 			subdocumentArray: [
 				{
 					prop1: { type: 'string', path: '3' },
@@ -179,7 +179,7 @@ describe('createSubdocumentFromRecord', () => {
 					prop3: [{ type: 'string', path: '5' }],
 				},
 			],
-		};
+		} satisfies SchemaDefinition;
 		const schema = new Schema(definition);
 
 		const document = Document.createSubdocumentFromRecord(schema, [
@@ -204,7 +204,7 @@ describe('createSubdocumentFromRecord', () => {
 	});
 
 	test('should create a new subdocument with a subdocument array from the provided record and sparse arrays', () => {
-		const definition: SchemaDefinition = {
+		const definition = {
 			subdocumentArray: [
 				{
 					prop1: { type: 'string', path: '3' },
@@ -212,7 +212,7 @@ describe('createSubdocumentFromRecord', () => {
 					prop3: [{ type: 'string', path: '5' }],
 				},
 			],
-		};
+		} satisfies SchemaDefinition;
 		const schema = new Schema(definition);
 
 		const document = Document.createSubdocumentFromRecord(schema, [
@@ -239,10 +239,10 @@ describe('createSubdocumentFromRecord', () => {
 
 describe('createSubdocumentFromData', () => {
 	test('should create a new subdocument from the provided data', () => {
-		const definition: SchemaDefinition = {
+		const definition = {
 			prop1: { type: 'string', path: '1' },
 			prop2: { type: 'number', path: '2', dbDecimals: 2 },
-		};
+		} satisfies SchemaDefinition;
 		const schema = new Schema(definition);
 
 		const document = Document.createSubdocumentFromData(schema, { prop1: 'foo', prop2: 1.23 });
@@ -254,10 +254,10 @@ describe('createSubdocumentFromData', () => {
 
 describe('createDocumentFromRecordString', () => {
 	test('should create a new document from the provided record string', () => {
-		const definition: SchemaDefinition = {
+		const definition = {
 			prop1: { type: 'string', path: '3' },
 			prop2: { type: 'number', path: '4', dbDecimals: 2 },
-		};
+		} satisfies SchemaDefinition;
 		const schema = new Schema(definition);
 
 		const document = Document.createDocumentFromRecordString(
@@ -271,9 +271,9 @@ describe('createDocumentFromRecordString', () => {
 	});
 
 	test('should create a new document with an array from the provided record string', () => {
-		const definition: SchemaDefinition = {
+		const definition = {
 			arrayProp: [{ type: 'string', path: '3' }],
-		};
+		} satisfies SchemaDefinition;
 		const schema = new Schema(definition);
 
 		const document = Document.createDocumentFromRecordString(
@@ -286,9 +286,9 @@ describe('createDocumentFromRecordString', () => {
 	});
 
 	test('should create a new document with an array from the provided record string with sparse data', () => {
-		const definition: SchemaDefinition = {
+		const definition = {
 			arrayProp: [{ type: 'string', path: '3' }],
-		};
+		} satisfies SchemaDefinition;
 		const schema = new Schema(definition);
 
 		const document = Document.createDocumentFromRecordString(
@@ -301,9 +301,9 @@ describe('createDocumentFromRecordString', () => {
 	});
 
 	test('should create a new document with a nested array from the provided record string', () => {
-		const definition: SchemaDefinition = {
+		const definition = {
 			nestedArrayProp: [[{ type: 'string', path: '3' }]],
-		};
+		} satisfies SchemaDefinition;
 		const schema = new Schema(definition);
 
 		const document = Document.createDocumentFromRecordString(
@@ -319,9 +319,9 @@ describe('createDocumentFromRecordString', () => {
 	});
 
 	test('should create a new document with a nested array from the provided record string with sparse data', () => {
-		const definition: SchemaDefinition = {
+		const definition = {
 			nestedArrayProp: [[{ type: 'string', path: '3' }]],
-		};
+		} satisfies SchemaDefinition;
 		const schema = new Schema(definition);
 
 		const document = Document.createDocumentFromRecordString(
@@ -337,7 +337,7 @@ describe('createDocumentFromRecordString', () => {
 	});
 
 	test('should create a new document with a subdocument array from the provided record string', () => {
-		const definition: SchemaDefinition = {
+		const definition = {
 			subdocumentArray: [
 				{
 					prop1: { type: 'string', path: '3' },
@@ -345,7 +345,7 @@ describe('createDocumentFromRecordString', () => {
 					prop3: [{ type: 'string', path: '5' }],
 				},
 			],
-		};
+		} satisfies SchemaDefinition;
 		const schema = new Schema(definition);
 
 		const document = Document.createDocumentFromRecordString(
@@ -363,7 +363,7 @@ describe('createDocumentFromRecordString', () => {
 	});
 
 	test('should create a new document with a subdocument array from the provided record string with sparse data', () => {
-		const definition: SchemaDefinition = {
+		const definition = {
 			subdocumentArray: [
 				{
 					prop1: { type: 'string', path: '3' },
@@ -371,7 +371,7 @@ describe('createDocumentFromRecordString', () => {
 					prop3: [{ type: 'string', path: '5' }],
 				},
 			],
-		};
+		} satisfies SchemaDefinition;
 		const schema = new Schema(definition);
 
 		const document = Document.createDocumentFromRecordString(
@@ -389,9 +389,9 @@ describe('createDocumentFromRecordString', () => {
 	});
 
 	test('should create a new document from the provided record string containing only values', () => {
-		const definition: SchemaDefinition = {
+		const definition = {
 			prop1: [{ type: 'string', path: '1' }],
-		};
+		} satisfies SchemaDefinition;
 		const schema = new Schema(definition);
 
 		const document = Document.createDocumentFromRecordString(
@@ -404,9 +404,9 @@ describe('createDocumentFromRecordString', () => {
 	});
 
 	test('should create a new document from the provided record string containing only subvalues', () => {
-		const definition: SchemaDefinition = {
+		const definition = {
 			prop1: [[{ type: 'string', path: '1' }]],
-		};
+		} satisfies SchemaDefinition;
 		const schema = new Schema(definition);
 
 		const document = Document.createDocumentFromRecordString(
@@ -419,14 +419,14 @@ describe('createDocumentFromRecordString', () => {
 	});
 
 	test('should create a new document from the provided record string using document arrays at subvalue positions', () => {
-		const definition: SchemaDefinition = {
+		const definition = {
 			subdocumentArray: [
 				{
 					prop1: { type: 'string', path: '1.1' },
 					prop2: { type: 'number', path: '1.2', dbDecimals: 2 },
 				},
 			],
-		};
+		} satisfies SchemaDefinition;
 		const schema = new Schema(definition);
 
 		const document = Document.createDocumentFromRecordString(
@@ -496,7 +496,7 @@ describe('transformDocumentToRecord', () => {
 	});
 
 	test('should transform document with schema to record if properties are not defined', () => {
-		const definition: SchemaDefinition = {
+		const definition = {
 			prop1: { type: 'string', path: '1' },
 			prop2: { type: 'number', path: '2', dbDecimals: 2 },
 			array: [{ type: 'string', path: '3' }],
@@ -511,10 +511,11 @@ describe('transformDocumentToRecord', () => {
 					prop2: { type: 'number', path: '8', dbDecimals: 2 },
 				},
 			],
-		};
+		} satisfies SchemaDefinition;
 		const schema = new Schema(definition);
 
 		const data = {};
+		// @ts-expect-error: intentionally invalid data to test behavior
 		const document = new DocumentSubclass(schema, { data });
 
 		const expected: MvRecord = [null, null, [], [], null, null, null, null];
@@ -522,7 +523,7 @@ describe('transformDocumentToRecord', () => {
 	});
 
 	test('should transform document with schema to record, retaining original record properties that are not mapped in schema', () => {
-		const definition: SchemaDefinition = {
+		const definition = {
 			prop1: { type: 'string', path: '2' },
 			prop2: { type: 'number', path: '4', dbDecimals: 2 },
 			array: [{ type: 'string', path: '6' }],
@@ -537,7 +538,7 @@ describe('transformDocumentToRecord', () => {
 					prop2: { type: 'number', path: '16', dbDecimals: 2 },
 				},
 			],
-		};
+		} satisfies SchemaDefinition;
 		const schema = new Schema(definition);
 
 		const record = [
@@ -592,10 +593,10 @@ describe('transformDocumentToRecord', () => {
 	});
 
 	test('should transform subdocument to record, leaving all unmapped positions as undefined', () => {
-		const definition: SchemaDefinition = {
+		const definition = {
 			prop1: { type: 'string', path: '2' },
 			prop2: { type: 'number', path: '4', dbDecimals: 2 },
-		};
+		} satisfies SchemaDefinition;
 		const schema = new Schema(definition);
 
 		const document = Document.createSubdocumentFromRecord(schema, [
@@ -612,14 +613,14 @@ describe('transformDocumentToRecord', () => {
 	});
 
 	test('should transform document arrays at subvalue position', () => {
-		const definition: SchemaDefinition = {
+		const definition = {
 			subdocumentArray: [
 				{
 					prop1: { type: 'string', path: '1.1' },
 					prop2: { type: 'number', path: '1.2', dbDecimals: 2 },
 				},
 			],
-		};
+		} satisfies SchemaDefinition;
 		const schema = new Schema(definition);
 
 		const data = {
@@ -648,9 +649,9 @@ describe('buildForeignKeyDefinitions', () => {
 	});
 
 	test('should build foreign key definitions for strings', () => {
-		const definition: SchemaDefinition = {
+		const definition = {
 			prop1: { type: 'string', path: '1', foreignKey: { entityName: 'entityName', file: 'FILE' } },
-		};
+		} satisfies SchemaDefinition;
 		const schema = new Schema(definition);
 
 		const document = new DocumentSubclass(schema, { data: { prop1: 'foo' } });
@@ -662,7 +663,7 @@ describe('buildForeignKeyDefinitions', () => {
 	});
 
 	test('should build multiple foreign key definitions for strings', () => {
-		const definition: SchemaDefinition = {
+		const definition = {
 			prop1: {
 				type: 'string',
 				path: '1',
@@ -673,7 +674,7 @@ describe('buildForeignKeyDefinitions', () => {
 				path: '2',
 				foreignKey: { entityName: 'entityName2', file: 'FILE2' },
 			},
-		};
+		} satisfies SchemaDefinition;
 		const schema = new Schema(definition);
 
 		const document = new DocumentSubclass(schema, { data: { prop1: 'foo', prop2: 'bar' } });
@@ -686,10 +687,10 @@ describe('buildForeignKeyDefinitions', () => {
 	});
 
 	test('should consolidate foreign keys for duplicate files', () => {
-		const definition: SchemaDefinition = {
+		const definition = {
 			prop1: { type: 'string', path: '1', foreignKey: { entityName: 'entityName', file: 'FILE' } },
 			prop2: { type: 'string', path: '2', foreignKey: { entityName: 'entityName', file: 'FILE' } },
-		};
+		} satisfies SchemaDefinition;
 		const schema = new Schema(definition);
 
 		const document = new DocumentSubclass(schema, { data: { prop1: 'foo', prop2: 'bar' } });
@@ -701,11 +702,11 @@ describe('buildForeignKeyDefinitions', () => {
 	});
 
 	test('should create multiple foreign key definitions for array content', () => {
-		const definition: SchemaDefinition = {
+		const definition = {
 			prop1: [
 				{ type: 'string', path: '1', foreignKey: { entityName: 'entityName', file: 'FILE' } },
 			],
-		};
+		} satisfies SchemaDefinition;
 		const schema = new Schema(definition);
 
 		const document = new DocumentSubclass(schema, { data: { prop1: ['foo', 'bar'] } });
@@ -717,7 +718,7 @@ describe('buildForeignKeyDefinitions', () => {
 	});
 
 	test('should create foreign key definitions for document array content', () => {
-		const definition: SchemaDefinition = {
+		const definition = {
 			documentArray: [
 				{
 					prop1: {
@@ -732,7 +733,7 @@ describe('buildForeignKeyDefinitions', () => {
 					},
 				},
 			],
-		};
+		} satisfies SchemaDefinition;
 		const schema = new Schema(definition);
 
 		const document = new DocumentSubclass(schema, {
@@ -752,13 +753,14 @@ describe('buildForeignKeyDefinitions', () => {
 	});
 
 	test('should build foreign key definitions for ids', () => {
-		const definition: SchemaDefinition = {
+		const definition = {
 			prop1: { type: 'string', path: '1' },
-		};
+		} satisfies SchemaDefinition;
 		const schema = new Schema(definition, {
 			idForeignKey: { entityName: 'entityName', file: 'FILE' },
 		});
 
+		// @ts-expect-error: _id is not a valid Document property. See note regarding relocation in Document.ts.
 		const document = new DocumentSubclass(schema, { data: { _id: 'id', prop1: 'foo' } });
 
 		const expected: BuildForeignKeyDefinitionsResult[] = [
@@ -768,13 +770,13 @@ describe('buildForeignKeyDefinitions', () => {
 	});
 
 	test('should build foreign key definitions with multiple filenames', () => {
-		const definition: SchemaDefinition = {
+		const definition = {
 			prop1: {
 				type: 'string',
 				path: '1',
 				foreignKey: { entityName: 'entityName', file: ['FILE1', 'FILE2'] },
 			},
-		};
+		} satisfies SchemaDefinition;
 		const schema = new Schema(definition);
 
 		const document = new DocumentSubclass(schema, { data: { prop1: 'foo' } });
@@ -795,14 +797,15 @@ describe('validate', () => {
 	});
 
 	describe('id matching validation', () => {
-		const definition: SchemaDefinition = {
+		const definition = {
 			prop1: { type: 'string', path: '1' },
-		};
+		} satisfies SchemaDefinition;
 		const schema = new Schema(definition, {
 			idMatch: /^foo$/,
 		});
 
 		test('should return error if id match is specified and id does not match pattern', () => {
+			// @ts-expect-error: _id is not a valid Document property. See note regarding relocation in Document.ts.
 			const document = new DocumentSubclass(schema, { data: { _id: 'id', prop1: 'foo' } });
 
 			const expected = new Map([['_id', ['Document id does not match pattern']]]);
@@ -810,6 +813,7 @@ describe('validate', () => {
 		});
 
 		test('should not return error if id match is specified and id matches pattern', () => {
+			// @ts-expect-error: _id is not a valid Document property. See note regarding relocation in Document.ts.
 			const document = new DocumentSubclass(schema, { data: { _id: 'foo', prop1: 'foo' } });
 
 			const expected = new Map();
@@ -819,9 +823,9 @@ describe('validate', () => {
 
 	describe('schema type validation', () => {
 		test('should return error at property if schemaType validation fails', () => {
-			const definition: SchemaDefinition = {
+			const definition = {
 				prop1: { type: 'string', path: '1', required: true },
-			};
+			} satisfies SchemaDefinition;
 			const schema = new Schema(definition);
 			const document = new DocumentSubclass(schema, { record: [] });
 
@@ -830,9 +834,9 @@ describe('validate', () => {
 		});
 
 		test('should not return error at property if schemaType validation is successful', () => {
-			const definition: SchemaDefinition = {
+			const definition = {
 				prop1: { type: 'string', path: '1', required: true },
-			};
+			} satisfies SchemaDefinition;
 			const schema = new Schema(definition);
 			const document = new DocumentSubclass(schema, { record: ['foo'] });
 
@@ -882,7 +886,7 @@ describe('validate', () => {
 				prop1: [{ type: 'string', path: '21', required: true }],
 				prop2: { type: 'number', path: '22', dbDecimals: 2, required: true },
 			});
-			const definition: SchemaDefinition = {
+			const definition = {
 				passingProp: { type: 'string', path: '1', required: true },
 				failingProp: { type: 'number', path: '2', dbDecimals: 2, required: true },
 				passingArray: [{ type: 'string', path: '3', required: true }],
@@ -913,7 +917,7 @@ describe('validate', () => {
 				failingSchema,
 				passingSchemaDocumentArray: [passingDocumentArraySchema],
 				failingSchemaDocumentArray: [failingDocumentArraySchema],
-			};
+			} satisfies SchemaDefinition;
 			const schema = new Schema(definition);
 			const record = [
 				'55', // passingProp

--- a/src/__tests__/Query.test.ts
+++ b/src/__tests__/Query.test.ts
@@ -2181,6 +2181,41 @@ describe('utility types', () => {
 			expect(test1).toBe(true);
 		});
 
+		test('should construct filter type excluding arrays that do not have a dictionary defined', () => {
+			const schema = new Schema({
+				hasArrayDictionary: [{ type: 'string', path: '1', dictionary: 'STRING_PROP' }],
+				noArrayDictionary: [{ type: 'string', path: '2' }],
+				hasNestedDictionary: [[{ type: 'string', path: '3', dictionary: 'NESTED_STRING_PROP' }]],
+				noNestedDictionary: [[{ type: 'string', path: '4' }]],
+				documentArray: [
+					{
+						hasDictionary: { type: 'string', path: '5', dictionary: 'STRING_PROP' },
+						noDictionary: { type: 'string', path: '6' },
+					},
+				],
+				documentArraySchema: [
+					new Schema({
+						hasDictionary: { type: 'string', path: '7', dictionary: 'STRING_PROP' },
+						noDictionary: { type: 'string', path: '8' },
+					}),
+				],
+			});
+
+			const test1: Equals<
+				Filter<typeof schema>,
+				{
+					$and?: readonly Filter<typeof schema>[];
+					$or?: readonly Filter<typeof schema>[];
+					hasArrayDictionary?: Condition<string | null>;
+					hasNestedDictionary?: Condition<string | null>;
+					'documentArray.hasDictionary'?: Condition<string | null>;
+					'documentArraySchema.hasDictionary'?: Condition<string | null>;
+					_id?: Condition<string>;
+				}
+			> = true;
+			expect(test1).toBe(true);
+		});
+
 		test('should construct filter type from all possible dictionary formats', () => {
 			const schema = new Schema(
 				{},
@@ -2468,6 +2503,42 @@ describe('utility types', () => {
 			const test1: Equals<
 				SortCriteria<typeof schema>,
 				readonly ['embedded.hasDictionary' | 'schema.hasDictionary' | '_id', -1 | 1][]
+			> = true;
+			expect(test1).toBe(true);
+		});
+
+		test('should construct sort criteria excluding arrays that do not have a dictionary defined', () => {
+			const schema = new Schema({
+				hasArrayDictionary: [{ type: 'string', path: '1', dictionary: 'STRING_PROP' }],
+				noArrayDictionary: [{ type: 'string', path: '2' }],
+				hasNestedDictionary: [[{ type: 'string', path: '3', dictionary: 'NESTED_STRING_PROP' }]],
+				noNestedDictionary: [[{ type: 'string', path: '4' }]],
+				documentArray: [
+					{
+						hasDictionary: { type: 'string', path: '5', dictionary: 'STRING_PROP' },
+						noDictionary: { type: 'string', path: '6' },
+					},
+				],
+				documentArraySchema: [
+					new Schema({
+						hasDictionary: { type: 'string', path: '7', dictionary: 'STRING_PROP' },
+						noDictionary: { type: 'string', path: '8' },
+					}),
+				],
+			});
+
+			const test1: Equals<
+				SortCriteria<typeof schema>,
+				readonly [
+					(
+						| 'hasArrayDictionary'
+						| 'hasNestedDictionary'
+						| 'documentArray.hasDictionary'
+						| 'documentArraySchema.hasDictionary'
+						| '_id'
+					),
+					-1 | 1,
+				][]
 			> = true;
 			expect(test1).toBe(true);
 		});

--- a/src/__tests__/Schema.test.ts
+++ b/src/__tests__/Schema.test.ts
@@ -32,8 +32,7 @@ import type { Equals, ISOCalendarDate, ISOCalendarDateTime, ISOTime, MvRecord } 
 describe('constructor', () => {
 	describe('errors', () => {
 		test('should throw InvalidParameterError if array definition contains multiple elements', () => {
-			const definition: SchemaDefinition = {
-				// @ts-expect-error: intentionally passing invalid argument to test
+			const definition = {
 				prop1: [
 					{ type: 'string', path: '1' },
 					{ type: 'string', path: '2' },
@@ -41,14 +40,14 @@ describe('constructor', () => {
 			};
 
 			expect(() => {
+				// @ts-expect-error: intentionally passing invalid argument to test
 				new Schema(definition);
 			}).toThrow(InvalidParameterError);
 		});
 
 		test('should throw InvalidParameterError if nested array definition contains multiple elements', () => {
-			const definition: SchemaDefinition = {
+			const definition = {
 				prop1: [
-					// @ts-expect-error: intentionally passing invalid argument to test
 					[
 						{ type: 'string', path: '1' },
 						{ type: 'string', path: '2' },
@@ -57,6 +56,7 @@ describe('constructor', () => {
 			};
 
 			expect(() => {
+				// @ts-expect-error: intentionally passing invalid argument to test
 				new Schema(definition);
 			}).toThrow(InvalidParameterError);
 		});
@@ -75,14 +75,14 @@ describe('constructor', () => {
 
 	describe('path setup', () => {
 		test('should construct a schema with all possible schemaTypes', () => {
-			const embeddedDefinition: SchemaDefinition = {
+			const embeddedDefinition = {
 				innerEmbeddedProp: { type: 'string', path: '9', dictionary: 'innerEmbeddedPropDict' },
-			};
-			const documentArrayDefinition: SchemaDefinition = {
+			} satisfies SchemaDefinition;
+			const documentArrayDefinition = {
 				docStringProp: { type: 'string', path: '12', dictionary: 'docStringPropDict' },
 				docNumberProp: { type: 'number', path: '13', dictionary: 'docNumberPropDict' },
-			};
-			const definition: SchemaDefinition = {
+			} satisfies SchemaDefinition;
+			const definition = {
 				stringProp: { type: 'string', path: '1', dictionary: 'stringPropDict' },
 				numberProp: { type: 'number', path: '2', dictionary: 'numberPropDict' },
 				booleanProp: { type: 'boolean', path: '3', dictionary: 'booleanPropDict' },
@@ -107,7 +107,7 @@ describe('constructor', () => {
 					},
 				],
 				documentArraySchemaProp: [new Schema(documentArrayDefinition)],
-			};
+			} satisfies SchemaDefinition;
 
 			const schema = new Schema(definition);
 			expect(schema.dictPaths.get('_id')).toEqual({
@@ -277,14 +277,14 @@ describe('constructor', () => {
 
 describe('getMvPaths', () => {
 	test('should return all multivalue paths', () => {
-		const embeddedDefinition: SchemaDefinition = {
+		const embeddedDefinition = {
 			innerEmbeddedProp: { type: 'string', path: '9' },
-		};
-		const documentArrayDefinition: SchemaDefinition = {
+		} satisfies SchemaDefinition;
+		const documentArrayDefinition = {
 			docStringProp: { type: 'string', path: '12' },
 			docNumberProp: { type: 'number', path: '13' },
-		};
-		const definition: SchemaDefinition = {
+		} satisfies SchemaDefinition;
+		const definition = {
 			stringProp: { type: 'string', path: '1' },
 			stringValueProp: { type: 'string', path: '14.2' },
 			numberProp: { type: 'number', path: '2' },
@@ -302,7 +302,7 @@ describe('getMvPaths', () => {
 				},
 			],
 			documentArraySchemaProp: [new Schema(documentArrayDefinition)],
-		};
+		} satisfies SchemaDefinition;
 		const schema = new Schema(definition);
 
 		const expected: number[][] = [
@@ -326,14 +326,14 @@ describe('getMvPaths', () => {
 });
 
 describe('transformPathsToDbPositions', () => {
-	const embeddedDefinition: SchemaDefinition = {
+	const embeddedDefinition = {
 		innerEmbeddedProp: { type: 'string', path: '9' },
-	};
-	const documentArrayDefinition: SchemaDefinition = {
+	} satisfies SchemaDefinition;
+	const documentArrayDefinition = {
 		docStringProp: { type: 'string', path: '12' },
 		docNumberProp: { type: 'number', path: '13' },
-	};
-	const definition: SchemaDefinition = {
+	} satisfies SchemaDefinition;
+	const definition = {
 		stringProp: { type: 'string', path: '1' },
 		stringValueProp: { type: 'string', path: '14.2' },
 		numberProp: { type: 'number', path: '2' },
@@ -351,7 +351,7 @@ describe('transformPathsToDbPositions', () => {
 			},
 		],
 		documentArraySchemaProp: [new Schema(documentArrayDefinition)],
-	};
+	} satisfies SchemaDefinition;
 	const schema = new Schema(definition);
 
 	test('should return no positions if path list is empty', () => {

--- a/src/__tests__/compileModel.test.ts
+++ b/src/__tests__/compileModel.test.ts
@@ -2,6 +2,7 @@ import { mock, mockDeep } from 'jest-mock-extended';
 import { getError, NoErrorThrownError } from '#test/helpers';
 import mockDelimiters from '#test/mockDelimiters';
 import type {
+	IncrementOperation,
 	ModelDeleteByIdOptions,
 	ModelFindByIdOptions,
 	ModelFindOptions,
@@ -1319,6 +1320,75 @@ describe('type inference', () => {
 			// any other property should be unknown
 			const test4: Equals<Result['otherProp'], unknown> = true;
 			expect(test4).toBe(true);
+		});
+	});
+});
+
+describe('utility types', () => {
+	describe('IncrementOperation', () => {
+		test('should include number and embedded number types in path', () => {
+			const incrementSchema = new Schema({
+				boolean: { type: 'boolean', path: '1' },
+				string: { type: 'string', path: '2' },
+				number: { type: 'number', path: '3' },
+				isoCalendarDate: { type: 'ISOCalendarDate', path: '4' },
+				isoTime: { type: 'ISOTime', path: '5' },
+				isoCalendarDateTime: { type: 'ISOCalendarDateTime', path: '6' },
+				arrayNumber: [{ type: 'number', path: '7' }],
+				nestedArrayNumber: [[{ type: 'string', path: '8' }]],
+				schema: new Schema({
+					boolean: { type: 'boolean', path: '9' },
+					string: { type: 'string', path: '10' },
+					number: { type: 'number', path: '11' },
+					isoCalendarDate: { type: 'ISOCalendarDate', path: '12' },
+					isoTime: { type: 'ISOTime', path: '13' },
+					isoCalendarDateTime: { type: 'ISOCalendarDateTime', path: '14' },
+					arrayNumber: [{ type: 'number', path: '15' }],
+					nestedArrayNumber: [[{ type: 'string', path: '16' }]],
+				}),
+				embedded: {
+					boolean: { type: 'boolean', path: '17' },
+					string: { type: 'string', path: '18' },
+					number: { type: 'number', path: '19' },
+					isoCalendarDate: { type: 'ISOCalendarDate', path: '20' },
+					isoTime: { type: 'ISOTime', path: '21' },
+					isoCalendarDateTime: { type: 'ISOCalendarDateTime', path: '22' },
+					arrayNumber: [{ type: 'number', path: '23' }],
+					nestedArrayNumber: [[{ type: 'string', path: '24' }]],
+				},
+				documentArray: [
+					{
+						boolean: { type: 'boolean', path: '25' },
+						string: { type: 'string', path: '26' },
+						number: { type: 'number', path: '27' },
+						isoCalendarDate: { type: 'ISOCalendarDate', path: '28' },
+						isoTime: { type: 'ISOTime', path: '29' },
+						isoCalendarDateTime: { type: 'ISOCalendarDateTime', path: '30' },
+						arrayNumber: [{ type: 'number', path: '31' }],
+					},
+				],
+				documentArraySchema: [
+					new Schema({
+						boolean: { type: 'boolean', path: '32' },
+						string: { type: 'string', path: '33' },
+						number: { type: 'number', path: '34' },
+						isoCalendarDate: { type: 'ISOCalendarDate', path: '35' },
+						isoTime: { type: 'ISOTime', path: '36' },
+						isoCalendarDateTime: { type: 'ISOCalendarDateTime', path: '37' },
+						arrayNumber: [{ type: 'number', path: '38' }],
+					}),
+				],
+			});
+
+			const test1: Equals<
+				IncrementOperation<typeof incrementSchema>,
+				{
+					path: 'number' | 'schema.number' | 'embedded.number';
+					value: number;
+				}
+			> = true;
+
+			expect(test1).toBe(true);
 		});
 	});
 });

--- a/src/schemaType/__tests__/DocumentArrayType.test.ts
+++ b/src/schemaType/__tests__/DocumentArrayType.test.ts
@@ -6,10 +6,10 @@ import type { MvRecord } from '../../types';
 import DocumentArrayType from '../DocumentArrayType';
 
 describe('cast', () => {
-	const definition: SchemaDefinition = {
+	const definition = {
 		prop1: { type: 'string', path: '2' },
 		prop2: { type: 'number', path: '3', dbDecimals: 2 },
-	};
+	} satisfies SchemaDefinition;
 	const valueSchema = new Schema(definition);
 	const documentArrayType = new DocumentArrayType(valueSchema);
 
@@ -57,10 +57,10 @@ describe('cast', () => {
 });
 
 describe('get', () => {
-	const definition: SchemaDefinition = {
+	const definition = {
 		prop1: { type: 'string', path: '2' },
 		prop2: { type: 'number', path: '3', dbDecimals: 2 },
-	};
+	} satisfies SchemaDefinition;
 	const valueSchema = new Schema(definition);
 	const documentArrayType = new DocumentArrayType(valueSchema);
 
@@ -97,10 +97,10 @@ describe('get', () => {
 
 describe('set', () => {
 	test('should return a record with the subdocument array merged in', () => {
-		const definition: SchemaDefinition = {
+		const definition = {
 			prop1: { type: 'string', path: '2' },
 			prop2: { type: 'number', path: '3', dbDecimals: 2 },
-		};
+		} satisfies SchemaDefinition;
 		const valueSchema = new Schema(definition);
 		const documentArrayType = new DocumentArrayType(valueSchema);
 
@@ -118,10 +118,10 @@ describe('set', () => {
 	});
 
 	test('should return a record with the subdocument array merged in and clear existing extra subdocument', () => {
-		const definition: SchemaDefinition = {
+		const definition = {
 			prop1: { type: 'string', path: '2' },
 			prop2: { type: 'number', path: '3', dbDecimals: 2 },
-		};
+		} satisfies SchemaDefinition;
 		const valueSchema = new Schema(definition);
 		const documentArrayType = new DocumentArrayType(valueSchema);
 
@@ -143,10 +143,10 @@ describe('set', () => {
 	});
 
 	test('should return a record with the subdocument array merged in when the document has missing schema properties', () => {
-		const definition: SchemaDefinition = {
+		const definition = {
 			prop1: { type: 'string', path: '2' },
 			prop2: { type: 'number', path: '3', dbDecimals: 2 },
-		};
+		} satisfies SchemaDefinition;
 		const valueSchema = new Schema(definition);
 		const documentArrayType = new DocumentArrayType(valueSchema);
 
@@ -162,10 +162,10 @@ describe('set', () => {
 	});
 
 	test('should return a record with the subdocument array merged in when the schema definition is using multi-part paths', () => {
-		const definition: SchemaDefinition = {
+		const definition = {
 			prop1: { type: 'string', path: '2.1' },
 			prop2: { type: 'number', path: '2.2', dbDecimals: 2 },
-		};
+		} satisfies SchemaDefinition;
 		const valueSchema = new Schema(definition);
 		const documentArrayType = new DocumentArrayType(valueSchema);
 
@@ -189,10 +189,10 @@ describe('set', () => {
 	});
 
 	test('should return a record with the subdocument array merged in when the schema definition is using multi-part paths and clear existing extra subdocument', () => {
-		const definition: SchemaDefinition = {
+		const definition = {
 			prop1: { type: 'string', path: '2.1' },
 			prop2: { type: 'number', path: '2.2', dbDecimals: 2 },
-		};
+		} satisfies SchemaDefinition;
 		const valueSchema = new Schema(definition);
 		const documentArrayType = new DocumentArrayType(valueSchema);
 
@@ -222,11 +222,11 @@ describe('set', () => {
 	});
 
 	test('should return a record with the subdocument array merged in when subdocuments include arrays', () => {
-		const definition: SchemaDefinition = {
+		const definition = {
 			prop1: { type: 'string', path: '2' },
 			prop2: { type: 'number', path: '3', dbDecimals: 2 },
 			prop3: [{ type: 'string', path: '4' }],
-		};
+		} satisfies SchemaDefinition;
 		const valueSchema = new Schema(definition);
 		const documentArrayType = new DocumentArrayType(valueSchema);
 
@@ -255,10 +255,10 @@ describe('set', () => {
 });
 
 describe('validate', () => {
-	const definition: SchemaDefinition = {
+	const definition = {
 		prop1: { type: 'string', path: '2', required: true },
 		prop2: { type: 'number', path: '3', dbDecimals: 2, required: true },
-	};
+	} satisfies SchemaDefinition;
 	const valueSchema = new Schema(definition);
 	const documentArrayType = new DocumentArrayType(valueSchema);
 
@@ -296,10 +296,10 @@ describe('validate', () => {
 
 describe('transformForeignKeyDefinitionsToDb', () => {
 	const foreignKeyDefinition = { file: 'FILE', entityName: 'FK_ENTITY' };
-	const definition: SchemaDefinition = {
+	const definition = {
 		prop1: { type: 'string', path: '2', foreignKey: foreignKeyDefinition },
 		prop2: { type: 'number', path: '3', dbDecimals: 2 },
-	};
+	} satisfies SchemaDefinition;
 	const valueSchema = new Schema(definition);
 	const documentArrayType = new DocumentArrayType(valueSchema);
 

--- a/src/schemaType/__tests__/EmbeddedType.test.ts
+++ b/src/schemaType/__tests__/EmbeddedType.test.ts
@@ -5,10 +5,10 @@ import type { MvRecord } from '../../types';
 import EmbeddedType from '../EmbeddedType';
 
 describe('cast', () => {
-	const definition: SchemaDefinition = {
+	const definition = {
 		prop1: { type: 'string', path: '2' },
 		prop2: { type: 'number', path: '3', dbDecimals: 2 },
-	};
+	} satisfies SchemaDefinition;
 	const valueSchema = new Schema(definition);
 	const embeddedType = new EmbeddedType(valueSchema);
 
@@ -36,10 +36,10 @@ describe('cast', () => {
 });
 
 describe('get', () => {
-	const definition: SchemaDefinition = {
+	const definition = {
 		prop1: { type: 'string', path: '2' },
 		prop2: { type: 'number', path: '3', dbDecimals: 2 },
-	};
+	} satisfies SchemaDefinition;
 	const valueSchema = new Schema(definition);
 	const embeddedType = new EmbeddedType(valueSchema);
 
@@ -54,10 +54,10 @@ describe('get', () => {
 });
 
 describe('set', () => {
-	const definition: SchemaDefinition = {
+	const definition = {
 		prop1: { type: 'string', path: '2' },
 		prop2: { type: 'number', path: '3', dbDecimals: 2 },
-	};
+	} satisfies SchemaDefinition;
 	const valueSchema = new Schema(definition);
 	const embeddedType = new EmbeddedType(valueSchema);
 
@@ -75,10 +75,10 @@ describe('set', () => {
 });
 
 describe('validate', () => {
-	const definition: SchemaDefinition = {
+	const definition = {
 		prop1: { type: 'string', path: '2', required: true },
 		prop2: { type: 'number', path: '3', dbDecimals: 2, required: true },
-	};
+	} satisfies SchemaDefinition;
 	const valueSchema = new Schema(definition);
 	const embeddedType = new EmbeddedType(valueSchema);
 


### PR DESCRIPTION
This PR fixes a type issue with the `Filter` and `SortCriteria` types when the schema includes scalar arrays without a dictionary specified in the definition. Any schema property without a dictionary should be excluded from the output of these utility types. However, due to a flaw in the constraint application in `InferDocumentObject`, the scalar definition of arrays is not being processed by the constraint check. This is because the constraint check in `InferDocumentObject` is on the entire property and is therefore bypassed for arrays. This caused the `Filter` and `SortCriteria`, which constrain to only those properties with a `dictionary` property, to errantly include scalar array properties without a dictionary defined.

The solution to this is to ensure that the scalar definition of a scalar array passes the supplied constraint. A new utility type `InferArraySchemaType` was added to assist in this which was then used in the existing `InferSchemaType` utility type.

New tests have been added to the utility type checks for `Filter` and `SortCriteria` to confirm this. In addition, tests were added for the `IncrementOperation` utility type to confirm that works as expected.

Finally, two unrelated changes were made. First, any variable declared as `SchemaDefinition` was changed to `satisfies SchemaDefinition` to ensure proper type inference of those objects. While testing, some new type errors appeared related to the use of `_id` in the `Document` class. The logic handling this property is inappropriately in this class as `_id` isn't a `Document` property but rather a `Model` property. I've added `TODO` notes to move this logic to the appropriate class at a later date.