### PR TITLE
Relocate ID checks from Document to Model

### DIFF
--- a/src/Document.ts
+++ b/src/Document.ts
@@ -1,9 +1,11 @@
 import { assignIn, cloneDeep, get as getIn, set as setIn } from 'lodash';
 import { TransformDataError } from './errors';
-import ForeignKeyDbTransformer from './ForeignKeyDbTransformer';
 import type Schema from './Schema';
 import type { InferDocumentObject } from './Schema';
 import type { DbServerDelimiters, DeepOptionalNullable, MvRecord } from './types';
+
+/** U2 does not allow pound signs in filenames so we can use it to separate filename/entityName combinations */
+const FOREIGN_KEY_SEPARATOR = '#';
 
 // #region Types
 /** Type of data property for constructing a document dependent upon the schema */
@@ -156,8 +158,6 @@ class Document<TSchema extends Schema | null> {
 			return [];
 		}
 
-		// U2 does not allow pound signs in filenames so we can use it to separate filename/entityName combinations
-		const separator = '#';
 		const definitionMap = Array.from(this.#schema.paths).reduce(
 			(foreignKeyDefinitions, [keyPath, schemaType]) => {
 				const value = getIn(this, keyPath, null);
@@ -165,7 +165,7 @@ class Document<TSchema extends Schema | null> {
 				// Deduplicate foreign key definitions by using a filename / entity name combination
 				// We could deduplicate using just the filename but ignoring the entity name could result in confusing error messages
 				definitions.forEach(({ filename, entityId, entityName }) => {
-					const key = `${filename}${separator}${entityName}`;
+					const key = `${filename}${FOREIGN_KEY_SEPARATOR}${entityName}`;
 					const accumulatedEntityIds = foreignKeyDefinitions.get(key) ?? new Set<string>();
 					// For array types we may need to validate multiple foreign keys
 					accumulatedEntityIds.add(entityId);
@@ -177,26 +177,15 @@ class Document<TSchema extends Schema | null> {
 			new Map<string, Set<string>>(),
 		);
 
-		if (this.#schema.idForeignKey != null) {
-			const foreignKeyDbTransformer = new ForeignKeyDbTransformer(this.#schema.idForeignKey);
-			const definitions = foreignKeyDbTransformer.transform(this._id);
-			definitions.forEach(({ filename, entityId, entityName }) => {
-				const key = `${filename}${separator}${entityName}`;
-				const accumulatedEntityIds = definitionMap.get(key) ?? new Set<string>();
-				accumulatedEntityIds.add(entityId);
-				definitionMap.set(key, accumulatedEntityIds);
-			});
-		}
-
 		return Array.from(definitionMap).reduce<BuildForeignKeyDefinitionsResult[]>(
 			(acc, [key, value]) => {
-				const keyParts = key.split(separator);
+				const keyParts = key.split(FOREIGN_KEY_SEPARATOR);
 				const fileName = keyParts[0];
 				// If an array of filenames was provided, when we transformed the array into a string above, commas
 				// would have been inserted between each filename. Split the string back into an array.
 				const filename = fileName.split(',');
 				// Just incase the entity name included a pound sign, rejoin
-				const entityName = keyParts.slice(1).join(separator);
+				const entityName = keyParts.slice(1).join(FOREIGN_KEY_SEPARATOR);
 				acc.push({ filename, entityName, entityIds: Array.from(value) });
 				return acc;
 			},

--- a/src/Document.ts
+++ b/src/Document.ts
@@ -149,10 +149,7 @@ class Document<TSchema extends Schema | null> {
 				);
 	}
 
-	/**
-	 * Build a list of foreign key definitions to be used by the database for foreign key validation
-	 * TODO: Foreign keys are a Model concept and not a Document concept. Relocate this logic.
-	 */
+	/** Build a list of foreign key definitions to be used by the database for foreign key validation */
 	public buildForeignKeyDefinitions(): BuildForeignKeyDefinitionsResult[] {
 		if (this.#schema === null) {
 			return [];

--- a/src/Document.ts
+++ b/src/Document.ts
@@ -209,15 +209,6 @@ class Document<TSchema extends Schema | null> {
 		const documentErrors = new Map<string, string[]>();
 
 		if (this.#schema !== null) {
-			// TODO: _id is a Model concept and not a Document concept. Relocate this logic.
-			if (
-				typeof this._id === 'string' &&
-				this.#schema.idMatch != null &&
-				!this.#schema.idMatch.test(this._id)
-			) {
-				documentErrors.set('_id', ['Document id does not match pattern']);
-			}
-
 			Array.from(this.#schema.paths).forEach(([keyPath, schemaType]) => {
 				const originalValue: unknown = getIn(this, keyPath, null);
 				// cast to complex data type if necessary

--- a/src/__tests__/Document.test.ts
+++ b/src/__tests__/Document.test.ts
@@ -806,23 +806,6 @@ describe('buildForeignKeyDefinitions', () => {
 		expect(document.buildForeignKeyDefinitions()).toEqual(expected);
 	});
 
-	test('should build foreign key definitions for ids', () => {
-		const definition = {
-			prop1: { type: 'string', path: '1' },
-		} satisfies SchemaDefinition;
-		const schema = new Schema(definition, {
-			idForeignKey: { entityName: 'entityName', file: 'FILE' },
-		});
-
-		// @ts-expect-error: _id is not a valid Document property. See note regarding relocation in Document.ts.
-		const document = new DocumentSubclass(schema, { data: { _id: 'id', prop1: 'foo' } });
-
-		const expected: BuildForeignKeyDefinitionsResult[] = [
-			{ filename: ['FILE'], entityName: 'entityName', entityIds: ['id'] },
-		];
-		expect(document.buildForeignKeyDefinitions()).toEqual(expected);
-	});
-
 	test('should build foreign key definitions with multiple filenames', () => {
 		const definition = {
 			prop1: {

--- a/src/__tests__/Document.test.ts
+++ b/src/__tests__/Document.test.ts
@@ -796,31 +796,6 @@ describe('validate', () => {
 		expect(document.validate()).toEqual(expected);
 	});
 
-	describe('id matching validation', () => {
-		const definition = {
-			prop1: { type: 'string', path: '1' },
-		} satisfies SchemaDefinition;
-		const schema = new Schema(definition, {
-			idMatch: /^foo$/,
-		});
-
-		test('should return error if id match is specified and id does not match pattern', () => {
-			// @ts-expect-error: _id is not a valid Document property. See note regarding relocation in Document.ts.
-			const document = new DocumentSubclass(schema, { data: { _id: 'id', prop1: 'foo' } });
-
-			const expected = new Map([['_id', ['Document id does not match pattern']]]);
-			expect(document.validate()).toEqual(expected);
-		});
-
-		test('should not return error if id match is specified and id matches pattern', () => {
-			// @ts-expect-error: _id is not a valid Document property. See note regarding relocation in Document.ts.
-			const document = new DocumentSubclass(schema, { data: { _id: 'foo', prop1: 'foo' } });
-
-			const expected = new Map();
-			expect(document.validate()).toEqual(expected);
-		});
-	});
-
 	describe('schema type validation', () => {
 		test('should return error at property if schemaType validation fails', () => {
 			const definition = {

--- a/src/__tests__/compileModel.test.ts
+++ b/src/__tests__/compileModel.test.ts
@@ -748,52 +748,69 @@ describe('readFileContentsById', () => {
 });
 
 describe('save', () => {
-	test('should throw TypeError if _id is not set', async () => {
-		const Model = compileModel(connectionMock, schema, filename, mockDelimiters, logHandlerMock);
+	describe('errors', () => {
+		test('should throw TypeError if _id is not set', async () => {
+			const Model = compileModel(connectionMock, schema, filename, mockDelimiters, logHandlerMock);
 
-		const model = new Model({ record: '' });
+			const model = new Model({ record: '' });
 
-		await expect(model.save()).rejects.toThrow(TypeError);
-	});
+			await expect(model.save()).rejects.toThrow(TypeError);
+		});
 
-	test('should reject save if validation is not successful', async () => {
-		const Model = compileModel(connectionMock, schema, filename, mockDelimiters, logHandlerMock);
+		test('should reject save if validation is not successful', async () => {
+			const Model = compileModel(connectionMock, schema, filename, mockDelimiters, logHandlerMock);
 
-		const id = 'id';
-		// @ts-expect-error: intentionally invalid data to trigger validation failure
-		const model = new Model({ _id: id, data: { prop1: 1337 } });
-		model.validate = () => new Map([['prop1', ['Not good']]]);
+			const id = 'id';
+			// @ts-expect-error: intentionally invalid data to trigger validation failure
+			const model = new Model({ _id: id, data: { prop1: 'prop1', prop2: 'not-a-number-bad' } });
 
-		await expect(model.save()).rejects.toThrow(DataValidationError);
-	});
+			await expect(model.save()).rejects.toThrow(DataValidationError);
+		});
 
-	test('should catch, enrich, and rethrow errors returned from database operations', async () => {
-		const Model = compileModel(connectionMock, schema, filename, mockDelimiters, logHandlerMock);
-
-		const id = 'id';
-		const model = new Model({ _id: id, data: { prop1: 'prop1-value', prop2: 123 } });
-
-		const err = new Error('Test error');
-		connectionMock.executeDbSubroutine.mockRejectedValue(err);
-
-		const error = await getError<Error & { other: unknown }>(async () => model.save());
-
-		expect(error).not.toBeInstanceOf(NoErrorThrownError);
-		expect(error).toBeInstanceOf(Error);
-		expect(error.other).toEqual({ filename, _id: id });
-		expect(connectionMock.executeDbSubroutine).toHaveBeenCalledWith(
-			'save',
-			{
+		test('should reject save if _id validation is not successful', async () => {
+			const idSchema = new Schema(schemaDefinition, { idMatch: /^valid-id$/ });
+			const Model = compileModel(
+				connectionMock,
+				idSchema,
 				filename,
-				id,
-				__v: null,
-				record: `prop1-value${am}123`,
-				foreignKeyDefinitions: [
-					{ entityIds: ['prop1-value'], entityName: 'prop1', filename: ['FK_FILE'] },
-				],
-			},
-			{},
-		);
+				mockDelimiters,
+				logHandlerMock,
+			);
+
+			const id = 'invalid-id';
+			const model = new Model({ _id: id, data: { prop1: 'prop1-value', prop2: 123 } });
+
+			await expect(model.save()).rejects.toThrow(DataValidationError);
+		});
+
+		test('should catch, enrich, and rethrow errors returned from database operations', async () => {
+			const Model = compileModel(connectionMock, schema, filename, mockDelimiters, logHandlerMock);
+
+			const id = 'id';
+			const model = new Model({ _id: id, data: { prop1: 'prop1-value', prop2: 123 } });
+
+			const err = new Error('Test error');
+			connectionMock.executeDbSubroutine.mockRejectedValue(err);
+
+			const error = await getError<Error & { other: unknown }>(async () => model.save());
+
+			expect(error).not.toBeInstanceOf(NoErrorThrownError);
+			expect(error).toBeInstanceOf(Error);
+			expect(error.other).toEqual({ filename, _id: id });
+			expect(connectionMock.executeDbSubroutine).toHaveBeenCalledWith(
+				'save',
+				{
+					filename,
+					id,
+					__v: null,
+					record: `prop1-value${am}123`,
+					foreignKeyDefinitions: [
+						{ entityIds: ['prop1-value'], entityName: 'prop1', filename: ['FK_FILE'] },
+					],
+				},
+				{},
+			);
+		});
 	});
 
 	describe('success', () => {
@@ -1037,6 +1054,45 @@ describe('save', () => {
 					],
 				},
 				{ maxReturnPayloadSize, userDefined, requestId },
+			);
+		});
+
+		test('should save and return new model instance with valid id pattern match', async () => {
+			const idSchema = new Schema(schemaDefinition, { idMatch: /^valid-id$/ });
+			const Model = compileModel(
+				connectionMock,
+				idSchema,
+				filename,
+				mockDelimiters,
+				logHandlerMock,
+			);
+
+			const id = 'valid-id';
+			const version = '1';
+			const model = new Model({ _id: id, data: { prop1: 'prop1-value', prop2: 123 } });
+
+			connectionMock.executeDbSubroutine.mockResolvedValue({
+				result: { _id: id, __v: version, record: `prop1-value${am}123` },
+			});
+			const result = await model.save();
+
+			expect(result).toBeInstanceOf(Model);
+			expect(result._id).toBe(id);
+			expect(result.__v).toBe(version);
+			expect(result.prop1).toBe('prop1-value');
+			expect(result.prop2).toBe(123);
+			expect(connectionMock.executeDbSubroutine).toHaveBeenCalledWith(
+				'save',
+				{
+					filename,
+					id,
+					__v: null,
+					record: `prop1-value${am}123`,
+					foreignKeyDefinitions: [
+						{ entityIds: ['prop1-value'], entityName: 'prop1', filename: ['FK_FILE'] },
+					],
+				},
+				{},
 			);
 		});
 	});

--- a/src/schemaType/EmbeddedType.ts
+++ b/src/schemaType/EmbeddedType.ts
@@ -1,5 +1,6 @@
 import { cloneDeep, isPlainObject, set as setIn } from 'lodash';
 import Document from '../Document';
+import type { ForeignKeyDbDefinition } from '../ForeignKeyDbTransformer';
 import type Schema from '../Schema';
 import type { MvRecord } from '../types';
 import BaseSchemaType from './BaseSchemaType';
@@ -53,6 +54,16 @@ class EmbeddedType<TSchema extends Schema> extends BaseSchemaType {
 	public validate(document: Document<TSchema>): Map<string, string[]> {
 		// - validation against the embedded document will return a single object with 0 to n keys - only those with keys indicate errors;
 		return document.validate();
+	}
+
+	/** Create an array of foreign key definitions that will be validated before save */
+	public override transformForeignKeyDefinitionsToDb(
+		document: Document<TSchema>,
+	): ForeignKeyDbDefinition[] {
+		const documentForeignKeyDefinitions = document.buildForeignKeyDefinitions();
+		return documentForeignKeyDefinitions.flatMap(({ filename, entityName, entityIds }) =>
+			entityIds.map((entityId) => ({ filename, entityName, entityId })),
+		);
 	}
 }
 


### PR DESCRIPTION
A `Document` instance does not have an `_id` property. This property is specific to a `Model` instance. However, there exists validations on the `Document` instance to ensure that the `_id` has the correct pattern match as well as the construction of the foreign key definitions for the `_id` property.

This PR relocates the logic for validating an `_id` pattern and building the `_id` foreign key definitions from the `Document` class to the `Model` subclass.

Additionally, while doing this work, I noticed that embedded schemas are not properly building foreign key definitions as no logic was implemented to do so. The embedded schema type has been updated to build foreign key definitions.