### PR TITLE
Improve database error types and handling

### DIFF
--- a/src/Connection.ts
+++ b/src/Connection.ts
@@ -38,7 +38,6 @@ import type {
 	DbSubroutineInputIncrement,
 	DbSubroutineInputOptionsMap,
 	DbSubroutineInputSave,
-	DbSubroutineOutputErrorForeignKey,
 	DbSubroutinePayload,
 	DbSubroutineResponseError,
 	DbSubroutineResponseTypes,
@@ -441,7 +440,7 @@ class Connection {
 		}
 
 		if ('errorCode' in response.data.output) {
-			const errorCode = Number(response.data.output.errorCode);
+			const { errorCode } = response.data.output;
 			switch (errorCode) {
 				case dbErrors.foreignKeyValidation.code: {
 					const { filename, id } = options as DbSubroutineInputSave;
@@ -449,8 +448,7 @@ class Connection {
 						`foreign key violations found when saving record ${id} to ${filename}`,
 					);
 					throw new ForeignKeyValidationError({
-						foreignKeyValidationErrors: (response.data.output as DbSubroutineOutputErrorForeignKey)
-							.foreignKeyValidationErrors,
+						foreignKeyValidationErrors: response.data.output.foreignKeyValidationErrors,
 						filename,
 						recordId: id,
 					});

--- a/src/constants/dbErrors.ts
+++ b/src/constants/dbErrors.ts
@@ -3,7 +3,7 @@ interface DbError {
 	message: string;
 }
 
-const dbErrors: Record<string, DbError> = {
+const dbErrors = {
 	malformedInput: { code: 1, message: 'Malformed input passed to db server' },
 	unsupportedAction: { code: 2, message: 'Database server does not support the passed action' },
 	deployment: { code: 3, message: 'Error in database server feature deployment' },
@@ -31,6 +31,9 @@ const dbErrors: Record<string, DbError> = {
 	recordWriteUnknown: { code: 19, message: 'Unknown error writing database record' },
 	maxPayloadExceeded: { code: 20, message: 'Maximum return payload size exceeded' },
 	recordNotFound: { code: 21, message: 'Database record not found' },
-};
+} as const satisfies Record<string, DbError>;
+
+export type DbErrors = typeof dbErrors;
+export type DbErrorCodes = DbErrors[keyof DbErrors]['code'];
 
 export default dbErrors;

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,4 +1,4 @@
-export { default as dbErrors } from './dbErrors';
+export { default as dbErrors, type DbErrors, type DbErrorCodes } from './dbErrors';
 export { default as ISOCalendarDateFormat } from './ISOCalendarDateFormat';
 export { default as ISOCalendarDateTimeFormat } from './ISOCalendarDateTimeFormat';
 export { default as ISOTimeFormat } from './ISOTimeFormat';

--- a/src/errors/DbServerError.ts
+++ b/src/errors/DbServerError.ts
@@ -1,4 +1,5 @@
 import { dbErrors } from '../constants';
+import type { DbErrorCodes } from '../constants';
 import BaseError from './BaseError';
 
 interface DbServerErrorConstructorOptionsMessage {
@@ -6,7 +7,7 @@ interface DbServerErrorConstructorOptionsMessage {
 }
 
 interface DbServerErrorConstructorOptionsCode {
-	errorCode: number | string;
+	errorCode: DbErrorCodes;
 }
 
 type DbServerErrorConstructorOptions =
@@ -21,7 +22,7 @@ class DbServerError extends BaseError {
 		const message =
 			'message' in options
 				? options.message
-				: (Object.values(dbErrors).find((errorObj) => errorObj.code === +options.errorCode)
+				: (Object.values(dbErrors).find((errorObj) => errorObj.code === options.errorCode)
 						?.message ?? 'Unknown database server error');
 
 		super(message, name);

--- a/src/errors/__tests__/DbServerError.test.ts
+++ b/src/errors/__tests__/DbServerError.test.ts
@@ -4,7 +4,7 @@ import DbServerError from '../DbServerError';
 // use one of the codes from the errors table
 const dbError = Object.values(dbErrors)[0];
 
-test('should instantiate error with expected instance properties', (): void => {
+test('should instantiate error with expected instance properties', () => {
 	const error = new DbServerError({ errorCode: dbError.code });
 	const expected = {
 		name: 'DbServerError',
@@ -13,7 +13,7 @@ test('should instantiate error with expected instance properties', (): void => {
 	expect(error).toMatchObject(expected);
 });
 
-test('should allow for override of message', (): void => {
+test('should allow for override of message', () => {
 	const message = 'foo';
 	const error = new DbServerError({
 		message,
@@ -22,8 +22,9 @@ test('should allow for override of message', (): void => {
 	expect(error.message).toEqual(message);
 });
 
-test('should use default message if errorCode is not found', (): void => {
-	const error = new DbServerError({ errorCode: NaN }); // use NaN as a proxy for a number because it really should never be there
+test('should use default message if errorCode is not found', () => {
+	// @ts-expect-error: intentionally passing an invalid error code
+	const error = new DbServerError({ errorCode: -9999 });
 	const expectedMessage = 'Unknown database server error';
 	expect(error.message).toEqual(expectedMessage);
 });

--- a/src/types/DbSubroutineOutput.ts
+++ b/src/types/DbSubroutineOutput.ts
@@ -1,3 +1,4 @@
+import type { DbErrorCodes, DbErrors } from '../constants';
 import type { ForeignKeyValidationErrorData } from '../errors/ForeignKeyValidationError';
 
 export interface DbDocument {
@@ -6,41 +7,41 @@ export interface DbDocument {
 	record: string;
 }
 
-export interface DbSubroutineResponse<TOutput> {
+interface DbSubroutineResponse<TOutput> {
 	output: TOutput;
 }
 
-export interface DbSubroutineOutputDeleteById {
+interface DbSubroutineOutputDeleteById {
 	result: DbDocument | null;
 }
-export type DbSubroutineResponseDeleteById = DbSubroutineResponse<DbSubroutineOutputDeleteById>;
+type DbSubroutineResponseDeleteById = DbSubroutineResponse<DbSubroutineOutputDeleteById>;
 
 export interface DbSubroutineOutputFind {
 	count: number;
 	documents: DbDocument[];
 }
-export type DbSubroutineResponseFind = DbSubroutineResponse<DbSubroutineOutputFind>;
+type DbSubroutineResponseFind = DbSubroutineResponse<DbSubroutineOutputFind>;
 
-export interface DbSubroutineOutputFindById {
+interface DbSubroutineOutputFindById {
 	result: DbDocument | null;
 }
-export type DbSubroutineResponseFindById = DbSubroutineResponse<DbSubroutineOutputFindById>;
+type DbSubroutineResponseFindById = DbSubroutineResponse<DbSubroutineOutputFindById>;
 
-export interface DbSubroutineOutputFindByIds {
+interface DbSubroutineOutputFindByIds {
 	result: (DbDocument | null)[];
 }
-export type DbSubroutineResponseFindByIds = DbSubroutineResponse<DbSubroutineOutputFindByIds>;
+type DbSubroutineResponseFindByIds = DbSubroutineResponse<DbSubroutineOutputFindByIds>;
 
-export interface DbSubroutineOutputIncrement {
+interface DbSubroutineOutputIncrement {
 	originalDocument: DbDocument;
 	updatedDocument: DbDocument;
 }
-export type DbSubroutineResponseIncrement = DbSubroutineResponse<DbSubroutineOutputIncrement>;
+type DbSubroutineResponseIncrement = DbSubroutineResponse<DbSubroutineOutputIncrement>;
 
-export interface DbSubroutineOutputReadFileContentsById {
+interface DbSubroutineOutputReadFileContentsById {
 	result: string;
 }
-export type DbSubroutineResponseReadFileContentsById =
+type DbSubroutineResponseReadFileContentsById =
 	DbSubroutineResponse<DbSubroutineOutputReadFileContentsById>;
 
 /** Characters which delimit strings on multivalue database server */
@@ -63,19 +64,18 @@ export interface DbServerLimits {
 	/** Maximum length of a query */
 	maxSentenceLength: number;
 }
-export interface DbSubroutineOutputGetServerInfo {
+interface DbSubroutineOutputGetServerInfo {
 	date: number;
 	time: number;
 	delimiters: DbServerDelimiters;
 	limits: DbServerLimits;
 }
-export type DbSubroutineResponseGetServerInfo =
-	DbSubroutineResponse<DbSubroutineOutputGetServerInfo>;
+type DbSubroutineResponseGetServerInfo = DbSubroutineResponse<DbSubroutineOutputGetServerInfo>;
 
-export interface DbSubroutineOutputSave {
+interface DbSubroutineOutputSave {
 	result: DbDocument;
 }
-export type DbSubroutineResponseSave = DbSubroutineResponse<DbSubroutineOutputSave>;
+type DbSubroutineResponseSave = DbSubroutineResponse<DbSubroutineOutputSave>;
 
 export type DbSubroutineResponseTypes =
 	| DbSubroutineResponseDeleteById
@@ -98,17 +98,19 @@ export interface DbSubroutineResponseTypesMap {
 	save: DbSubroutineResponseSave;
 }
 
-export interface DbSubroutineOutputErrorBase {
-	errorCode: string;
-}
-export type DbSubroutineResponseErrorBase = DbSubroutineResponse<DbSubroutineOutputErrorBase>;
+type ForeignKeyValidationErrorCode = DbErrors['foreignKeyValidation']['code'];
+type BaseErrorCodes = Exclude<DbErrorCodes, ForeignKeyValidationErrorCode>;
 
-export interface DbSubroutineOutputErrorForeignKey extends DbSubroutineOutputErrorBase {
-	errorCode: '14';
+interface DbSubroutineOutputErrorBase {
+	errorCode: BaseErrorCodes;
+}
+type DbSubroutineResponseErrorBase = DbSubroutineResponse<DbSubroutineOutputErrorBase>;
+
+interface DbSubroutineOutputErrorForeignKey {
+	errorCode: ForeignKeyValidationErrorCode;
 	foreignKeyValidationErrors: ForeignKeyValidationErrorData[];
 }
-export type DbSubroutineResponseErrorForeignKey =
-	DbSubroutineResponse<DbSubroutineOutputErrorForeignKey>;
+type DbSubroutineResponseErrorForeignKey = DbSubroutineResponse<DbSubroutineOutputErrorForeignKey>;
 
 export type DbSubroutineResponseError =
 	| DbSubroutineResponseErrorBase


### PR DESCRIPTION
This PR makes the following changes:

1. The `dbErrors` mapping is now a const object which utilizes the `satisfies` operator to ensure proper structure. This allows the object to be treated as its literal values rather than simply an arbitrary record.
2. New types `DbErrors` and `DbErrorCodes` have been created to create a type of the `dbErrors` object and a union of the possible error codes.
3. The error types from the db subroutine outputs have been tightened so that a foreign key validation error has the specific code value from the `dbErrors` mapping and other errors are all other possible codes.
4. Bullet 3 allowed for the removal of a type assertion in the `Connection` error handler as the code is now able to properly narrow the type for a foreign key error response.
5. Casting error codes to number has been removed as the output from the database subroutines is an error and not a string.
6. Unnecessary exports from the `DbSubroutineOutput` types has been eliminated.