### PR TITLE
Add a checkForRecordLockById method

### DIFF
--- a/src/__tests__/compileModel.test.ts
+++ b/src/__tests__/compileModel.test.ts
@@ -74,6 +74,30 @@ describe('_id accessors', () => {
 	});
 });
 
+describe('checkForRecordLockById', () => {
+	test.each`
+		lockResult | expected
+		${0}       | ${true}
+		${1}       | ${false}
+		${-1}      | ${false}
+	`('should return $expected when lockResult is $lockResult', async ({ lockResult, expected }) => {
+		const Model = compileModel(connectionMock, schema, filename, mockDelimiters, logHandlerMock);
+
+		const id = 'id';
+		connectionMock.executeDbSubroutine.mockResolvedValue({ result: lockResult });
+
+		expect(await Model.checkForRecordLockById(id)).toBe(expected);
+		expect(connectionMock.executeDbSubroutine).toHaveBeenCalledWith(
+			'checkForRecordLockById',
+			{
+				filename,
+				id,
+			},
+			{},
+		);
+	});
+});
+
 describe('deleteById', () => {
 	test('should return null if database returns null', async () => {
 		const Model = compileModel(connectionMock, schema, filename, mockDelimiters, logHandlerMock);

--- a/src/__tests__/compileModel.test.ts
+++ b/src/__tests__/compileModel.test.ts
@@ -3,6 +3,7 @@ import { getError, NoErrorThrownError } from '#test/helpers';
 import mockDelimiters from '#test/mockDelimiters';
 import type {
 	IncrementOperation,
+	ModelCheckForRecordLockByIdOptions,
 	ModelDeleteByIdOptions,
 	ModelFindByIdOptions,
 	ModelFindOptions,
@@ -77,9 +78,9 @@ describe('_id accessors', () => {
 describe('checkForRecordLockById', () => {
 	test.each`
 		lockResult | expected
-		${0}       | ${true}
-		${1}       | ${false}
-		${-1}      | ${false}
+		${0}       | ${false}
+		${1}       | ${true}
+		${-1}      | ${true}
 	`('should return $expected when lockResult is $lockResult', async ({ lockResult, expected }) => {
 		const Model = compileModel(connectionMock, schema, filename, mockDelimiters, logHandlerMock);
 
@@ -94,6 +95,28 @@ describe('checkForRecordLockById', () => {
 				id,
 			},
 			{},
+		);
+	});
+
+	test('should pass setup options', async () => {
+		const Model = compileModel(connectionMock, schema, filename, mockDelimiters, logHandlerMock);
+
+		const id = 'id';
+		connectionMock.executeDbSubroutine.mockResolvedValue({ result: 1 });
+
+		const userDefined = { option1: 'foo', option2: 'bar', option3: 'biz' };
+		const maxReturnPayloadSize = 1000;
+		const options: ModelCheckForRecordLockByIdOptions = {
+			maxReturnPayloadSize,
+			requestId,
+			userDefined,
+		};
+
+		expect(await Model.checkForRecordLockById(id, options)).toBe(true);
+		expect(connectionMock.executeDbSubroutine).toHaveBeenCalledWith(
+			'checkForRecordLockById',
+			{ filename, id },
+			{ userDefined, maxReturnPayloadSize, requestId },
 		);
 	});
 });

--- a/src/compileModel.ts
+++ b/src/compileModel.ts
@@ -395,6 +395,15 @@ const compileModel = <TSchema extends Schema | null>(
 			return data.result;
 		}
 
+		public static async checkForRecordLockById(id: string): Promise<boolean> {
+			const data = await this.connection.executeDbSubroutine('checkForRecordLockById', {
+				filename: this.file,
+				id,
+			});
+
+			return data.result;
+		}
+
 		/** Create a new Model instance from a record string */
 		static #createModelFromRecordString(
 			recordString: string,

--- a/src/compileModel.ts
+++ b/src/compileModel.ts
@@ -401,7 +401,7 @@ const compileModel = <TSchema extends Schema | null>(
 				id,
 			});
 
-			return data.result;
+			return data.result !== 0;
 		}
 
 		/** Create a new Model instance from a record string */

--- a/src/compileModel.ts
+++ b/src/compileModel.ts
@@ -97,7 +97,7 @@ export type IncrementOperation<TSchema extends Schema | null> = TSchema extends 
 	: never;
 export type ModelReadFileContentsByIdOptions = ModelDatabaseExecutionOptions;
 export type ModelSaveOptions = ModelDatabaseExecutionOptions;
-export type CheckForRecordLockByIdOptions = ModelDatabaseExecutionOptions;
+export type ModelCheckForRecordLockByIdOptions = ModelDatabaseExecutionOptions;
 // #endregion
 
 /** Define a new model */
@@ -191,7 +191,7 @@ const compileModel = <TSchema extends Schema | null>(
 		 */
 		public static async checkForRecordLockById(
 			id: string,
-			options: CheckForRecordLockByIdOptions = {},
+			options: ModelCheckForRecordLockByIdOptions = {},
 		): Promise<boolean> {
 			const { maxReturnPayloadSize, requestId, userDefined } = options;
 			const data = await this.connection.executeDbSubroutine(
@@ -207,7 +207,7 @@ const compileModel = <TSchema extends Schema | null>(
 				},
 			);
 
-			return data.result === 0;
+			return data.result !== 0;
 		}
 
 		/** Delete a document */

--- a/src/compileModel.ts
+++ b/src/compileModel.ts
@@ -97,6 +97,7 @@ export type IncrementOperation<TSchema extends Schema | null> = TSchema extends 
 	: never;
 export type ModelReadFileContentsByIdOptions = ModelDatabaseExecutionOptions;
 export type ModelSaveOptions = ModelDatabaseExecutionOptions;
+export type CheckForRecordLockByIdOptions = ModelDatabaseExecutionOptions;
 // #endregion
 
 /** Define a new model */
@@ -395,13 +396,29 @@ const compileModel = <TSchema extends Schema | null>(
 			return data.result;
 		}
 
-		public static async checkForRecordLockById(id: string): Promise<boolean> {
-			const data = await this.connection.executeDbSubroutine('checkForRecordLockById', {
-				filename: this.file,
-				id,
-			});
+		/**
+		 * Check to see if a record is locked by another user/process
+		 * @returns `true` when record is locked
+		 */
+		public static async checkForRecordLockById(
+			id: string,
+			options: CheckForRecordLockByIdOptions = {},
+		): Promise<boolean> {
+			const { maxReturnPayloadSize, requestId, userDefined } = options;
+			const data = await this.connection.executeDbSubroutine(
+				'checkForRecordLockById',
+				{
+					filename: this.file,
+					id,
+				},
+				{
+					...(maxReturnPayloadSize != null && { maxReturnPayloadSize }),
+					...(requestId != null && { requestId }),
+					...(userDefined != null && { userDefined }),
+				},
+			);
 
-			return data.result !== 0;
+			return data.result;
 		}
 
 		/** Create a new Model instance from a record string */

--- a/src/compileModel.ts
+++ b/src/compileModel.ts
@@ -418,7 +418,7 @@ const compileModel = <TSchema extends Schema | null>(
 				},
 			);
 
-			return data.result !== 0;
+			return data.result !== 1;
 		}
 
 		/** Create a new Model instance from a record string */

--- a/src/compileModel.ts
+++ b/src/compileModel.ts
@@ -185,6 +185,31 @@ const compileModel = <TSchema extends Schema | null>(
 			});
 		}
 
+		/**
+		 * Check to see if a record is locked by another user/process
+		 * @returns `true` when record is locked
+		 */
+		public static async checkForRecordLockById(
+			id: string,
+			options: CheckForRecordLockByIdOptions = {},
+		): Promise<boolean> {
+			const { maxReturnPayloadSize, requestId, userDefined } = options;
+			const data = await this.connection.executeDbSubroutine(
+				'checkForRecordLockById',
+				{
+					filename: this.file,
+					id,
+				},
+				{
+					...(maxReturnPayloadSize != null && { maxReturnPayloadSize }),
+					...(requestId != null && { requestId }),
+					...(userDefined != null && { userDefined }),
+				},
+			);
+
+			return data.result === 0;
+		}
+
 		/** Delete a document */
 		public static async deleteById(
 			id: string,
@@ -394,31 +419,6 @@ const compileModel = <TSchema extends Schema | null>(
 			);
 
 			return data.result;
-		}
-
-		/**
-		 * Check to see if a record is locked by another user/process
-		 * @returns `true` when record is locked
-		 */
-		public static async checkForRecordLockById(
-			id: string,
-			options: CheckForRecordLockByIdOptions = {},
-		): Promise<boolean> {
-			const { maxReturnPayloadSize, requestId, userDefined } = options;
-			const data = await this.connection.executeDbSubroutine(
-				'checkForRecordLockById',
-				{
-					filename: this.file,
-					id,
-				},
-				{
-					...(maxReturnPayloadSize != null && { maxReturnPayloadSize }),
-					...(requestId != null && { requestId }),
-					...(userDefined != null && { userDefined }),
-				},
-			);
-
-			return data.result !== 1;
 		}
 
 		/** Create a new Model instance from a record string */

--- a/src/compileModel.ts
+++ b/src/compileModel.ts
@@ -418,7 +418,7 @@ const compileModel = <TSchema extends Schema | null>(
 				},
 			);
 
-			return data.result;
+			return data.result !== 0;
 		}
 
 		/** Create a new Model instance from a record string */

--- a/src/types/DbSubroutineInput.ts
+++ b/src/types/DbSubroutineInput.ts
@@ -86,6 +86,11 @@ export interface DbSubroutineInputSave {
 	foreignKeyDefinitions: BuildForeignKeyDefinitionsResult[];
 }
 
+export interface DbSubroutineInputCheckForRecordLock {
+	filename: string;
+	id: string;
+}
+
 export type DbActionSubroutineInputTypes = DbSubroutinePayload<
 	| DbSubroutineInputDeleteById
 	| DbSubroutineInputFind
@@ -94,6 +99,7 @@ export type DbActionSubroutineInputTypes = DbSubroutinePayload<
 	| DbSubroutineInputIncrement
 	| DbSubroutineInputReadFileContentsById
 	| DbSubroutineInputGetServerInfo
+	| DbSubroutineInputCheckForRecordLock
 >;
 
 export interface DbSubroutineInputOptionsMap {
@@ -105,4 +111,5 @@ export interface DbSubroutineInputOptionsMap {
 	readFileContentsById: DbSubroutineInputReadFileContentsById;
 	getServerInfo: DbSubroutineInputGetServerInfo;
 	save: DbSubroutineInputSave;
+	checkForRecordLockById: DbSubroutineInputCheckForRecordLock;
 }

--- a/src/types/DbSubroutineOutput.ts
+++ b/src/types/DbSubroutineOutput.ts
@@ -44,6 +44,12 @@ interface DbSubroutineOutputReadFileContentsById {
 type DbSubroutineResponseReadFileContentsById =
 	DbSubroutineResponse<DbSubroutineOutputReadFileContentsById>;
 
+interface DbSubroutineOutputCheckForRecordLock {
+	result: boolean;
+}
+type DbSubroutineResponseCheckForRecordLock =
+	DbSubroutineResponse<DbSubroutineOutputCheckForRecordLock>;
+
 /** Characters which delimit strings on multivalue database server */
 export interface DbServerDelimiters {
 	/** Record mark */
@@ -96,6 +102,7 @@ export interface DbSubroutineResponseTypesMap {
 	readFileContentsById: DbSubroutineResponseReadFileContentsById;
 	getServerInfo: DbSubroutineResponseGetServerInfo;
 	save: DbSubroutineResponseSave;
+	checkForRecordLockById: DbSubroutineResponseCheckForRecordLock;
 }
 
 type ForeignKeyValidationErrorCode = DbErrors['foreignKeyValidation']['code'];

--- a/src/types/DbSubroutineOutput.ts
+++ b/src/types/DbSubroutineOutput.ts
@@ -45,7 +45,7 @@ type DbSubroutineResponseReadFileContentsById =
 	DbSubroutineResponse<DbSubroutineOutputReadFileContentsById>;
 
 interface DbSubroutineOutputCheckForRecordLock {
-	result: number;
+	result: boolean;
 }
 type DbSubroutineResponseCheckForRecordLock =
 	DbSubroutineResponse<DbSubroutineOutputCheckForRecordLock>;

--- a/src/types/DbSubroutineOutput.ts
+++ b/src/types/DbSubroutineOutput.ts
@@ -45,7 +45,7 @@ type DbSubroutineResponseReadFileContentsById =
 	DbSubroutineResponse<DbSubroutineOutputReadFileContentsById>;
 
 interface DbSubroutineOutputCheckForRecordLock {
-	result: boolean;
+	result: number;
 }
 type DbSubroutineResponseCheckForRecordLock =
 	DbSubroutineResponse<DbSubroutineOutputCheckForRecordLock>;

--- a/src/types/DbSubroutineOutput.ts
+++ b/src/types/DbSubroutineOutput.ts
@@ -91,7 +91,8 @@ export type DbSubroutineResponseTypes =
 	| DbSubroutineResponseIncrement
 	| DbSubroutineResponseReadFileContentsById
 	| DbSubroutineResponseGetServerInfo
-	| DbSubroutineResponseSave;
+	| DbSubroutineResponseSave
+	| DbSubroutineResponseCheckForRecordLock;
 
 export interface DbSubroutineResponseTypesMap {
 	deleteById: DbSubroutineResponseDeleteById;

--- a/src/unibasicTemplates/main.njk
+++ b/src/unibasicTemplates/main.njk
@@ -98,3 +98,4 @@ response:
 {% include "./subroutines/external/readFileContentsById.njk" %}
 {% include "./subroutines/external/save.njk" %}
 {% include "./subroutines/external/increment.njk" %}
+{% include "./subroutines/external/checkForRecordLockById.njk" %}

--- a/src/unibasicTemplates/subroutines/external/checkForRecordLockById.njk
+++ b/src/unibasicTemplates/subroutines/external/checkForRecordLockById.njk
@@ -34,7 +34,5 @@ if udoSetProperty(output, 'result', result) then
   go returnFromSub
 end
 
-go returnFromSub
-
 returnFromSub:
 return; * returning to caller

--- a/src/unibasicTemplates/subroutines/external/checkForRecordLockById.njk
+++ b/src/unibasicTemplates/subroutines/external/checkForRecordLockById.njk
@@ -15,34 +15,14 @@ if udoGetProperty(options, 'id', recordId, type) then
   go returnFromSub
 end
 
-* open the file
-open filename to f.file on error
-  call error_handler(ERROR_FILE_OPEN, output)
-  go returnFromSub
-end else
-  call error_handler(ERROR_FILE_OPEN, output)
+lockStatus = recordLocked(filename, recordId)
+isLocked = lockStatus ne 0
+if udoSetProperty(output, 'result', isLocked) then
+  call error_handler(ERROR_UDO, output)
   go returnFromSub
 end
 
-* read and lock record from the file
-readu record from f.file, recordId on error
-  call error_handler(ERROR_RECORD_READ, output)
-  go closeAndReturnFromSub
-end locked
-  udoSetProperty(output, 'result', @TRUE)
-  go closeAndReturnFromSub
-end else
-  udoSetProperty(output, 'result', @FALSE)
-  go closeReleaseAndReturnFromSub
-end
-
-closeReleaseAndReturnFromSub:
-release f.file, recordId on error null
-* fall through to close and return
-
-closeAndReturnFromSub:
-close f.file on error null
-* fall through to return
+go returnFromSub
 
 returnFromSub:
 return; * returning to caller

--- a/src/unibasicTemplates/subroutines/external/checkForRecordLockById.njk
+++ b/src/unibasicTemplates/subroutines/external/checkForRecordLockById.njk
@@ -24,31 +24,17 @@ end else
   go returnFromSub
 end
 
-lockStatus = 0
+result = recordlocked(f.file, recordId)
 
-readu record from f.file, recordId on error
-  call error_handler(ERROR_RECORD_READ, output)
-  go closeAndReturnFromSub
-end locked
-  lockStatus = 1
-end then
-  lockStatus = 0
-end
-
-release f.file, recordId on error null
 close f.file on error null
 
-# set results property
-if udoSetProperty(output, 'result', lockStatus) then
+* set the result property
+if udoSetProperty(output, 'result', result) then
   call error_handler(ERROR_UDO, output)
   go returnFromSub
 end
 
 go returnFromSub
-
-closeAndReturnFromSub:
-close f.file on error null
-* fall through to return
 
 returnFromSub:
 return; * returning to caller

--- a/src/unibasicTemplates/subroutines/external/checkForRecordLockById.njk
+++ b/src/unibasicTemplates/subroutines/external/checkForRecordLockById.njk
@@ -18,6 +18,7 @@ end
 isLocked = @false
 lockStatus = recordLocked(filename, recordId)
 if lockStatus ne 0 then isLocked = @true
+
 if udoSetProperty(output, 'result', isLocked) then
   call error_handler(ERROR_UDO, output)
   go returnFromSub

--- a/src/unibasicTemplates/subroutines/external/checkForRecordLockById.njk
+++ b/src/unibasicTemplates/subroutines/external/checkForRecordLockById.njk
@@ -15,13 +15,9 @@ if udoGetProperty(options, 'id', recordId, type) then
   go returnFromSub
 end
 
-isLocked = @false
 lockStatus = recordLocked(filename, recordId)
-if lockStatus ne 0 then
-  isLocked = @true
-end
 
-if udoSetProperty(output, 'result', isLocked) then
+if udoSetProperty(output, 'result', lockStatus) then
   call error_handler(ERROR_UDO, output)
   go returnFromSub
 end

--- a/src/unibasicTemplates/subroutines/external/checkForRecordLockById.njk
+++ b/src/unibasicTemplates/subroutines/external/checkForRecordLockById.njk
@@ -1,4 +1,4 @@
-subroutine mvom_checkForRecorLockById(options, output)
+subroutine mvom_checkForRecordLockById(options, output)
 * check if there is a record locked on file *
 {% include "../../constants/udo.njk" %}
 {% include "../../constants/error.njk" %}

--- a/src/unibasicTemplates/subroutines/external/checkForRecordLockById.njk
+++ b/src/unibasicTemplates/subroutines/external/checkForRecordLockById.njk
@@ -15,14 +15,40 @@ if udoGetProperty(options, 'id', recordId, type) then
   go returnFromSub
 end
 
-lockStatus = recordLocked(filename, recordId)
+* open the file
+open filename to f.file on error
+  call error_handler(ERROR_FILE_OPEN, output)
+  go returnFromSub
+end else
+  call error_handler(ERROR_FILE_OPEN, output)
+  go returnFromSub
+end
 
+lockStatus = 0
+
+readu record from f.file, recordId on error
+  call error_handler(ERROR_RECORD_READ, output)
+  go closeAndReturnFromSub
+end locked
+  lockStatus = 1
+end then
+  lockStatus = 0
+end
+
+release f.file, recordId on error null
+close f.file on error null
+
+# set results property
 if udoSetProperty(output, 'result', lockStatus) then
   call error_handler(ERROR_UDO, output)
   go returnFromSub
 end
 
 go returnFromSub
+
+closeAndReturnFromSub:
+close f.file on error null
+* fall through to return
 
 returnFromSub:
 return; * returning to caller

--- a/src/unibasicTemplates/subroutines/external/checkForRecordLockById.njk
+++ b/src/unibasicTemplates/subroutines/external/checkForRecordLockById.njk
@@ -1,0 +1,48 @@
+subroutine mvom_checkForRecorLockById(options, output)
+* check if there is a record locked on file *
+{% include "../../constants/udo.njk" %}
+{% include "../../constants/error.njk" %}
+
+* get the filename from the options
+if udoGetProperty(options, 'filename', filename, type) then
+  call error_handler(ERROR_MALFORMED_INPUT, output)
+  go returnFromSub
+end
+
+* get the recordId from the options
+if udoGetProperty(options, 'id', recordId, type) then
+  call error_handler(ERROR_MALFORMED_INPUT, output)
+  go returnFromSub
+end
+
+* open the file
+open filename to f.file on error
+  call error_handler(ERROR_FILE_OPEN, output)
+  go returnFromSub
+end else
+  call error_handler(ERROR_FILE_OPEN, output)
+  go returnFromSub
+end
+
+* read and lock record from the file
+readu record from f.file, recordId on error
+  call error_handler(ERROR_RECORD_READ, output)
+  go closeAndReturnFromSub
+end locked
+  udoSetProperty(output, 'result', @TRUE)
+  go closeAndReturnFromSub
+end else
+  udoSetProperty(output, 'result', @FALSE)
+  go closeReleaseAndReturnFromSub
+end
+
+closeReleaseAndReturnFromSub:
+release f.file, recordId on error null
+* fall through to close and return
+
+closeAndReturnFromSub:
+close f.file on error null
+* fall through to return
+
+returnFromSub:
+return; * returning to caller

--- a/src/unibasicTemplates/subroutines/external/checkForRecordLockById.njk
+++ b/src/unibasicTemplates/subroutines/external/checkForRecordLockById.njk
@@ -15,8 +15,9 @@ if udoGetProperty(options, 'id', recordId, type) then
   go returnFromSub
 end
 
+isLocked = @false
 lockStatus = recordLocked(filename, recordId)
-isLocked = lockStatus ne 0
+if lockStatus ne 0 then isLocked = @true
 if udoSetProperty(output, 'result', isLocked) then
   call error_handler(ERROR_UDO, output)
   go returnFromSub

--- a/src/unibasicTemplates/subroutines/external/checkForRecordLockById.njk
+++ b/src/unibasicTemplates/subroutines/external/checkForRecordLockById.njk
@@ -17,7 +17,9 @@ end
 
 isLocked = @false
 lockStatus = recordLocked(filename, recordId)
-if lockStatus ne 0 then isLocked = @true
+if lockStatus ne 0 then
+  isLocked = @true
+end
 
 if udoSetProperty(output, 'result', isLocked) then
   call error_handler(ERROR_UDO, output)


### PR DESCRIPTION
### Summary
This PR implements a new `checkForRecordLockById` method to provide a way to easily check if there is another process locking a record before attempting a mutation on record.

#### TypeScript Changes
- Create Input and Output types for new `checkForRecordLockById` method
- Create new static method `checkForRecordLockById` on dynamically created Model class in `compileModel`

#### UniBasic Changes
- Created unibasicTemplate `checkForRecordLockById.njk`
   - Opens given file by filename
   - Runs UniBasic function `RECORDLOCKED` and returns the numeric result. Method `checkForRecordLockedById` will then return a `boolean` value where true represents the record being locked (any value other than 0).

### Testing Notes
Ran the following tests:
- Checked a record in a file that was not locked - correctly returns `false`
- Checked a record that was locked by me - correctly returns `true`
- Checked a record that was locked by another process - correctly return `true`
- Checked a record that does not exist - correctly returns `false`