### PR TITLE
Update how dates are queried

### DIFF
--- a/src/dataTransformers/ISOCalendarDateDataTransformer.ts
+++ b/src/dataTransformers/ISOCalendarDateDataTransformer.ts
@@ -47,9 +47,20 @@ class ISOCalendarDateDataTransformer implements DataTransformer {
 		return String(differenceInDays(this.parseISOCalendarDate(value), mvEpoch));
 	}
 
-	/** Transform query constants to internal u2 date format */
+	/** Transform query constants to ISOCalendarDate format */
 	public transformToQuery(value: unknown): string {
-		return value === '' || value == null ? '' : this.transformToDb(value);
+		if (value === '' || value == null) {
+			return '';
+		}
+
+		if (typeof value !== 'string') {
+			throw new TransformDataError({
+				transformClass: this.constructor.name,
+				transformValue: value,
+			});
+		}
+
+		return format(this.parseISOCalendarDate(value), ISOCalendarDateFormat);
 	}
 
 	/** Parse ISOCalendarDate string into date */

--- a/src/dataTransformers/ISOCalendarDateDataTransformer.ts
+++ b/src/dataTransformers/ISOCalendarDateDataTransformer.ts
@@ -60,7 +60,14 @@ class ISOCalendarDateDataTransformer implements DataTransformer {
 			});
 		}
 
-		return format(this.parseISOCalendarDate(value), ISOCalendarDateFormat);
+		try {
+			return format(this.parseISOCalendarDate(value), ISOCalendarDateFormat);
+		} catch (error) {
+			throw new TransformDataError({
+				transformClass: this.constructor.name,
+				transformValue: value,
+			});
+		}
 	}
 
 	/** Parse ISOCalendarDate string into date */

--- a/src/dataTransformers/__tests__/ISOCalendarDateDataTransformer.test.ts
+++ b/src/dataTransformers/__tests__/ISOCalendarDateDataTransformer.test.ts
@@ -62,10 +62,19 @@ describe('transformToQuery', () => {
 		expect(isoCalendarDateDataTransformer.transformToQuery(value)).toBe('');
 	});
 
-	test('should return the number of days since the multivalue epoch', () => {
+	test('should return the date in the yyyy-MM-dd format', () => {
 		const isoCalendarDateDataTransformer = new ISOCalendarDateDataTransformer();
 
 		const value = '2022-02-27';
-		expect(isoCalendarDateDataTransformer.transformToQuery(value)).toBe('19782');
+		expect(isoCalendarDateDataTransformer.transformToQuery(value)).toBe('2022-02-27');
+	});
+
+	test('should throw a TransformDataError when value is not a string', () => {
+		const isoCalendarDateDataTransformer = new ISOCalendarDateDataTransformer();
+
+		const value = 12345;
+		expect(() => isoCalendarDateDataTransformer.transformToQuery(value)).toThrow(
+			TransformDataError,
+		);
 	});
 });

--- a/src/dataTransformers/__tests__/ISOCalendarDateDataTransformer.test.ts
+++ b/src/dataTransformers/__tests__/ISOCalendarDateDataTransformer.test.ts
@@ -77,4 +77,15 @@ describe('transformToQuery', () => {
 			TransformDataError,
 		);
 	});
+
+	test.each(['12345', 'stringValue', '2025-02-30', '1', 'delete data'])(
+		'should throw a TransformDataError when value is not a valid ISOCalendarDate',
+		(value) => {
+			const isoCalendarDateDataTransformer = new ISOCalendarDateDataTransformer();
+
+			expect(() => isoCalendarDateDataTransformer.transformToQuery(value)).toThrow(
+				TransformDataError,
+			);
+		},
+	);
 });

--- a/src/unibasicTemplates/subroutines/external/find.njk
+++ b/src/unibasicTemplates/subroutines/external/find.njk
@@ -39,14 +39,14 @@ execute 'date.format 2'
 
 * execute the query
 udtexecute queryCommand returning errorCodes
-if @system.return.code lt 0 then
-  call error_handler(ERROR_QUERY, output)
-  execute 'date.format ':systemDateFormat
-  go returnFromSub
-end
 
 * set date.format back
 execute 'date.format ':systemDateFormat
+
+if @system.return.code lt 0 then
+  call error_handler(ERROR_QUERY, output)
+  go returnFromSub
+end
 
 * set the count property
 if udoSetProperty(output, 'count', system(11), UDO_NUMBER) then

--- a/src/unibasicTemplates/subroutines/external/find.njk
+++ b/src/unibasicTemplates/subroutines/external/find.njk
@@ -3,6 +3,12 @@ subroutine mvom_find(options, output)
 {% include "../../constants/udo.njk" %}
 {% include "../../constants/error.njk" %}
 
+* save the systems date format
+systemDateFormat = system(36)
+
+* change date format to 2
+execute date.format 2
+
 * get the filename from the options
 if udoGetProperty(options, 'filename', filename, type) then
   call error_handler(ERROR_MALFORMED_INPUT, output)
@@ -99,4 +105,5 @@ close f.file on error null
 * fall through to return
 
 returnFromSub:
+execute date.format systemDateFormat
 return; * returning to caller

--- a/src/unibasicTemplates/subroutines/external/find.njk
+++ b/src/unibasicTemplates/subroutines/external/find.njk
@@ -6,9 +6,6 @@ subroutine mvom_find(options, output)
 * save the systems date format
 systemDateFormat = system(36)
 
-* change date format to 2
-execute date.format 2
-
 * get the filename from the options
 if udoGetProperty(options, 'filename', filename, type) then
   call error_handler(ERROR_MALFORMED_INPUT, output)
@@ -37,12 +34,19 @@ if udoGetProperty(options, 'skip', skip, type) then
   skip = 0
 end
 
+* change date.format to 2
+execute 'date.format 2'
+
 * execute the query
 udtexecute queryCommand returning errorCodes
 if @system.return.code lt 0 then
   call error_handler(ERROR_QUERY, output)
+  execute 'date.format ':systemDateFormat
   go returnFromSub
 end
+
+* set date.format back
+execute 'date.format ':systemDateFormat
 
 * set the count property
 if udoSetProperty(output, 'count', system(11), UDO_NUMBER) then
@@ -105,5 +109,4 @@ close f.file on error null
 * fall through to return
 
 returnFromSub:
-execute date.format systemDateFormat
 return; * returning to caller


### PR DESCRIPTION
### Summary
This PR updates how properties typed as `ISOCalendarDate` are queried on in an effort to better handle dates that could be in different formats.

#### TypeScript Changes
Updates `ISOCalendarDateTransformer`'s `transformToQuery` method to now pass in a date query in the `ISOCalendarDate` format (yyyy-MM-dd) instead of the mv date (days since mv epoch)

#### UniBasic Changes
Updates `find.njk` subroutine to:
1. Capture the system `DATE.FORMAT` at beginning of subroutine 
2. Change `DATE.FORMAT` to `2` (international format) before executing query
3. Changes `DATE.FORMAT` back to whatever the system is set to after query executes

### Testing Notes
Tested that a query with a date parameter is now being queried as `select FOO with BAR >= "2025-04-01"` with date in `yyyy-MM-dd` format.