### PR TITLE
Prepare for version 3.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.2.1]
+
+### Fixed
+
+- Query dates consistently using ISO Date format to avoid issues with use of internal dates sometimes being parsed ([#907](https://github.com/STORIS/mvom/pull/907))
+
 ## [3.2.0]
 
 ### Added
@@ -543,7 +549,8 @@ We've graduated from Alpha to Beta! Semver has been updated so breaking vs. non-
 
 Initial alpha release of this library! Thanks for using it!
 
-[unreleased]: https://github.com/storis/mvom/compare/3.2.0...HEAD
+[unreleased]: https://github.com/storis/mvom/compare/3.2.1...HEAD
+[3.2.1]: https://github.com/storis/mvom/compare/3.2.0...3.2.1
 [3.2.0]: https://github.com/storis/mvom/compare/3.1.1...3.2.0
 [3.1.1]: https://github.com/storis/mvom/compare/3.1.0...3.1.1
 [3.1.0]: https://github.com/storis/mvom/compare/3.0.1...3.1.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mvom",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mvom",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.27.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mvom",
   "private": true,
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Multivalue Object Mapper",
   "main": "index.js",
   "engines": {

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -40,7 +40,7 @@ const config: Config = {
 					lastVersion: 'current',
 					versions: {
 						current: {
-							label: '3.2.0',
+							label: '3.2.1',
 						},
 					},
 					remarkPlugins: [[npm2YarnPlugin, { sync: true }]],
@@ -70,7 +70,7 @@ const config: Config = {
 				},
 				{
 					type: 'docsVersion',
-					label: '3.2.0',
+					label: '3.2.1',
 					position: 'right',
 				},
 				{


### PR DESCRIPTION
This PR makes the necessary changes to release a new version `3.2.1`. Included are updates to the following:

- `package.json` and `package-lock.json` versions
- Updates to `CHANGELOG` describing changes in this release
- Updates to documentation versions