### PR TITLE
Force cast of error code to numeric

### DIFF
--- a/src/unibasicTemplates/subroutines/internal/errorHandler.njk
+++ b/src/unibasicTemplates/subroutines/internal/errorHandler.njk
@@ -1,8 +1,9 @@
 subroutine error_handler(errorCode, output)
+{% include "../../constants/udo.njk" %}
 
 * note that this routine intentionally does not react to udo errors because it could
 * potentially result in an unending sequence of errors
 
-x = udoSetProperty(output, 'errorCode', errorCode)
+x = udoSetProperty(output, 'errorCode', errorCode, UDO_NUMBER)
 
 return


### PR DESCRIPTION
The `error_handler` UniBasic subroutine adds a numeric error code to the output JSON. However, because of inconsistent behavior from `UDOSetProperty`, that numeric value will sometimes be added to the JSON as a numeric string rather than a number. This PR updates the logic for setting this property to force a cast to a number.