### PR TITLE
Fix 960 boolean field inference

### DIFF
--- a/src/Schema.ts
+++ b/src/Schema.ts
@@ -145,7 +145,7 @@ type InferArraySchemaType<
 /** Infer the output type of a schema type definition */
 type InferSchemaType<TSchemaTypeDefinition, TConstraint> =
 	TSchemaTypeDefinition extends SchemaTypeDefinitionBoolean
-		? InferRequiredType<TSchemaTypeDefinition, boolean>
+		? boolean
 		: TSchemaTypeDefinition extends SchemaTypeDefinitionString
 			? InferRequiredType<TSchemaTypeDefinition, InferStringType<TSchemaTypeDefinition>>
 			: TSchemaTypeDefinition extends SchemaTypeDefinitionNumber

--- a/src/__tests__/Document.test.ts
+++ b/src/__tests__/Document.test.ts
@@ -1061,7 +1061,7 @@ describe('utility types', () => {
 			const test1: Equals<
 				DocumentData<typeof schema>,
 				{
-					boolean?: boolean | null;
+					boolean: boolean;
 					string?: string | null;
 					number?: number | null;
 					isoCalendarDate?: ISOCalendarDate | null;
@@ -1123,7 +1123,7 @@ describe('utility types', () => {
 			const test1: Equals<
 				DocumentData<typeof schema>,
 				{
-					booleanOptional?: boolean | null;
+					booleanOptional: boolean;
 					booleanRequired: boolean;
 					stringOptional?: string | null;
 					stringRequired: string;

--- a/src/__tests__/Query.test.ts
+++ b/src/__tests__/Query.test.ts
@@ -2403,7 +2403,7 @@ describe('utility types', () => {
 				{
 					$and?: readonly Filter<typeof schema>[];
 					$or?: readonly Filter<typeof schema>[];
-					booleanOptional?: Condition<boolean | null>;
+					booleanOptional?: Condition<boolean>;
 					booleanRequired?: Condition<boolean>;
 					stringOptional?: Condition<string | null>;
 					stringRequired?: Condition<string>;

--- a/src/__tests__/Schema.test.ts
+++ b/src/__tests__/Schema.test.ts
@@ -502,12 +502,9 @@ describe('utility types', () => {
 			});
 
 			test('should infer boolean type', () => {
-				// not required should be nullable
+				// boolean fields always return boolean (null is transformed to false)
 				const schema1 = new Schema({ booleanProp: { type: 'boolean', path: '1' } });
-				const test1: Equals<
-					InferDocumentObject<typeof schema1>,
-					{ booleanProp: boolean | null }
-				> = true;
+				const test1: Equals<InferDocumentObject<typeof schema1>, { booleanProp: boolean }> = true;
 				expect(test1).toBe(true);
 
 				// required should not be nullable
@@ -801,7 +798,7 @@ describe('utility types', () => {
 				const test1: Equals<
 					InferDocumentObject<typeof schema>,
 					{
-						booleanOptional: boolean | null;
+						booleanOptional: boolean;
 						booleanRequired: boolean;
 						stringOptional: string | null;
 						stringRequired: string;
@@ -896,11 +893,11 @@ describe('utility types', () => {
 			});
 
 			test('should infer boolean type', () => {
-				// not required should be nullable
+				// boolean fields always return boolean (null is transformed to false)
 				const schema1 = new Schema({ booleanProp: { type: 'boolean', path: '1' } });
 				const test1: Equals<
 					InferModelObject<typeof schema1>,
-					{ _id: string; __v: string; booleanProp: boolean | null }
+					{ _id: string; __v: string; booleanProp: boolean }
 				> = true;
 				expect(test1).toBe(true);
 
@@ -1226,7 +1223,7 @@ describe('utility types', () => {
 					{
 						_id: string;
 						__v: string;
-						booleanOptional: boolean | null;
+						booleanOptional: boolean;
 						booleanRequired: boolean;
 						stringOptional: string | null;
 						stringRequired: string;
@@ -1317,7 +1314,7 @@ describe('utility types', () => {
 			const test1: Equals<
 				FlattenDocument<typeof schema>,
 				{
-					booleanOptional: boolean | null;
+					booleanOptional: boolean;
 					booleanRequired: boolean;
 					stringOptional: string | null;
 					stringRequired: string;


### PR DESCRIPTION
Fixes #960

### Summary

This PR fixes TypeScript type inference for boolean schema fields to align with runtime behavior. Previously, boolean fields were typed as `boolean | null`, but the `BooleanDataTransformer` always converts `null` values to `false` at runtime, meaning boolean fields never actually return `null`. This change updates the type inference to correctly reflect that boolean fields always return `boolean`, eliminating a type-safety gap where TypeScript allowed `null` handling that would never execute.

### Technical Details

**Changed**: `InferSchemaType` type helper in `src/Schema.ts`
- Removed `InferRequiredType` wrapper from boolean type inference
- Boolean fields now directly infer as `boolean` regardless of the `required` property
- Other scalar types (string, number, date/time) continue to respect `required` and can still be `null`

### Breaking Changes

This is technically a breaking change for TypeScript consumers, though it corrects a type-safety issue:

- Code that previously handled `null` values for boolean fields will now show TypeScript errors
- However, such null checks were unnecessary since `null` is transformed to `false` at runtime
- Users needing true tri-state logic (true/false/null as distinct states) should use `string` type with `enum` constraint, as documented