### PR TITLE
Optimize ensureArray by not copying array

### DIFF
--- a/src/utils/__tests__/ensureArray.test.ts
+++ b/src/utils/__tests__/ensureArray.test.ts
@@ -4,6 +4,11 @@ test('should return an array if passed an array', () => {
 	expect(ensureArray(['foo', 'bar'])).toEqual(['foo', 'bar']);
 });
 
+test('should return the same array reference when passed an array', () => {
+	const input = ['foo', 'bar'];
+	expect(ensureArray(input)).toBe(input); // referential equality
+});
+
 test('should return an empty array if no value passed', () => {
 	expect(ensureArray()).toEqual([]);
 });

--- a/src/utils/ensureArray.ts
+++ b/src/utils/ensureArray.ts
@@ -1,6 +1,6 @@
 const ensureArray = <T>(value?: T | readonly T[]): T[] => {
 	if (Array.isArray(value)) {
-		return [...value];
+		return value;
 	}
 
 	if (typeof value === 'undefined') {


### PR DESCRIPTION
This PR updates the `ensureArray` utility function so that it no longer creates a shallow copy of the provided array. I reviewed all uses of `ensureArray` and confirmed that callers were not mutating the returned array.